### PR TITLE
Ticket 40505: Update test paths to new snprc module location

### DIFF
--- a/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
+++ b/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
@@ -234,9 +234,14 @@ public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOn
     }
 
     @Override
+    public String getModulePath() {
+        return "/server/modules/" + getModuleDirectory();
+    }
+
+    @Override
     protected void importStudy()
     {
-        File path = new File(TestFileUtils.getLabKeyRoot(), getExternalModulePath() + "/resources/referenceStudy");
+        File path = new File(TestFileUtils.getLabKeyRoot(), getModulePath() + "resources/referenceStudy");
         setPipelineRoot(path.getPath());
 
         beginAt(WebTestHelper.getBaseURL() + "/pipeline-status/" + getContainerPath() + "/begin.view");

--- a/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
+++ b/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
@@ -241,7 +241,7 @@ public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOn
     @Override
     protected void importStudy()
     {
-        File path = new File(TestFileUtils.getLabKeyRoot(), getModulePath() + "resources/referenceStudy");
+        File path = new File(TestFileUtils.getLabKeyRoot(), getModulePath() + "/resources/referenceStudy");
         setPipelineRoot(path.getPath());
 
         beginAt(WebTestHelper.getBaseURL() + "/pipeline-status/" + getContainerPath() + "/begin.view");

--- a/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
+++ b/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
@@ -53,7 +53,7 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
     protected static TestUser BAD_USER = new TestUser("bad_user@foo.bar", SecurityGroup.NO_ACCESS, SecurityRole.NO_ACCESS);
     protected ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
 
-    final static String SNPRC_EHR_PATH  = "externalModules/snprcEHRModules/snprc_ehr";
+    final static String SNPRC_EHR_PATH  = "modules/snprcEHRModules/snprc_ehr";
     private static Integer _pipelineJobCount = 0;
 
     private static final File PROTOCOL_TSV = TestFileUtils.getSampleData("ehr/protocol.tsv");

--- a/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
+++ b/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
@@ -53,7 +53,7 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
     protected static TestUser BAD_USER = new TestUser("bad_user@foo.bar", SecurityGroup.NO_ACCESS, SecurityRole.NO_ACCESS);
     protected ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
 
-    final static String SNPRC_EHR_PATH  = "modules/snprcEHRModules/snprc_ehr";
+    final static String SNPRC_EHR_PATH  = "server/modules/snprcEHRModules/snprc_ehr";
     private static Integer _pipelineJobCount = 0;
 
     private static final File PROTOCOL_TSV = TestFileUtils.getSampleData("ehr/protocol.tsv");


### PR DESCRIPTION
#### Rationale
Moving snprc modules to server/modules in the LabKey build required some path updates in automated tests.

There was also a change made in the EHR TeamCity build configuration to update the module path.

#### Related Pull Requests
https://github.com/LabKey/ehrModules/pull/51

#### Changes
Update module paths in SNPRC_EHRTest and SNPRC_schedulerTest
