### PR TITLE
Added acquisition and disposition categories to demographics queries

### DIFF
--- a/snprc_ehr/resources/queries/study/demographicsArrival.query.xml
+++ b/snprc_ehr/resources/queries/study/demographicsArrival.query.xml
@@ -26,6 +26,12 @@
                             query.description~eq=${MostRecentAcqDesc}&amp;
                         </url>
                     </column>
+                    <column columnName="MostRecentAcqCategory">
+                        <url>/query/executeQuery.view?schemaName=ehr_lookups&amp;
+                            query.queryName=acquisitionType&amp;
+                            query.description~eq=${MostRecentAcqCategory}&amp;
+                        </url>
+                    </column>
                     <column columnName="EarliestAcq">
                         <url>/query/executeQuery.view?schemaName=study&amp;
                             query.queryName=arrival&amp;
@@ -43,6 +49,12 @@
                         <url>/query/executeQuery.view?schemaName=ehr_lookups&amp;
                             query.queryName=acquisitionType&amp;
                             query.description~eq=${MostRecentAcqDesc}&amp;
+                        </url>
+                    </column>
+                    <column columnName="EarliestAcqCategory">
+                        <url>/query/executeQuery.view?schemaName=ehr_lookups&amp;
+                            query.queryName=acquisitionType&amp;
+                            query.value~eq=${EarliestAcqCategory}&amp;
                         </url>
                     </column>
                     <column columnName="Center_Arrival">

--- a/snprc_ehr/resources/queries/study/demographicsArrival.sql
+++ b/snprc_ehr/resources/queries/study/demographicsArrival.sql
@@ -9,12 +9,14 @@ SELECT
   T1.date as MostRecentAcq,
   T1.acquisitionType.value as MostRecentAcqType,
   T1.acquisitionType.Description as MostRecentAcqDesc,
+  T1.acquisitionType.category as MostRecentAcqCategory,
 
   T2.date as EarliestAcq,
   T2.acquisitionType.value as EarliestAcqType,
   T2.acquisitionType.Description as EarliestAcqDesc,
+  T2.acquisitionType.category as EarliestAcqCategory,
 
-  coalesce(T2.date, d.birth) as Center_Arrival,
+  coalesce(T2.date, d.birth) as Center_Arrival
 
 FROM study.demographics d
 

--- a/snprc_ehr/resources/queries/study/demographicsMostRecentDeparture.query.xml
+++ b/snprc_ehr/resources/queries/study/demographicsMostRecentDeparture.query.xml
@@ -26,6 +26,12 @@
                         query.description~eq=${MostRecentDispDesc}&amp;
                     </url>
                 </column>
+                <column columnName="MostRecentDispCategory">
+                    <url>/query/executeQuery.view?schemaName=ehr_lookups&amp;
+                        query.queryName=dispositionType&amp;
+                        query.description~eq=${MostRecentDispCategory}&amp;
+                    </url>
+                </column>
                 <column columnName="EarliestDisp">
                     <url>/query/executeQuery.view?schemaName=study&amp;
                         query.queryName=departure&amp;
@@ -43,6 +49,12 @@
                     <url>/query/executeQuery.view?schemaName=ehr_lookups&amp;
                         query.queryName=dispositionType&amp;
                         query.description~eq=${MostRecentDispDesc}&amp;
+                    </url>
+                </column>
+                <column columnName="EarliestDispCategory">
+                    <url>/query/executeQuery.view?schemaName=ehr_lookups&amp;
+                        query.queryName=dispositionType&amp;
+                        query.description~eq=${EarliestDispCategory}&amp;
                     </url>
                 </column>
             </columns>

--- a/snprc_ehr/resources/queries/study/demographicsMostRecentDeparture.sql
+++ b/snprc_ehr/resources/queries/study/demographicsMostRecentDeparture.sql
@@ -9,10 +9,12 @@ SELECT
   T1.date as MostRecentDisp,
   T1.dispositionType.value as MostRecentDispType,
   T1.dispositionType.Description as MostRecentDispDesc,
+  T1.dispositionType.category as MostRecentDispCategory,
 
   T2.date as EarliestDisp,
   T2.dispositionType.value as EarliestDispType,
-  T2.dispositionType.Description as EarliestDispDesc
+  T2.dispositionType.Description as EarliestDispDesc,
+  T2.dispositionType.category as EarliestDispCategory
 
 FROM study.demographics d
 


### PR DESCRIPTION
#### Rationale
Acquisition and disposition categories need to be exposed in the query grid customizer

#### Related Pull Requests
none

#### Changes
updated demographics queries and metadata with the category columns
