### PR TITLE
Enable Charts/Reports Animal History tabbed reports

### DIFF
--- a/snprc_ehr/resources/views/animalHistory.html
+++ b/snprc_ehr/resources/views/animalHistory.html
@@ -11,6 +11,7 @@
             defaultReport: ctx.DefaultAnimalHistoryReport,
             defaultTab: 'General',
             showFilterOptionsTitle: true,
+            showReportsOption:true,
             filterTypes: [{
                 xtype: 'ldk-singlesubjectfiltertype',
                 inputValue: LDK.panel.SingleSubjectFilterType.filterName,


### PR DESCRIPTION
#### Rationale
Allow users to create charts/reports in Animal History tabbed reports

#### Related Pull Requests
None

#### Changes
Set ShowReportsOption: true in AnimalHistoryPanel config
