### PR TITLE
eslint config change to enforce case sensitive paths in import statements

### DIFF
--- a/snprc_ehr/.eslintrc
+++ b/snprc_ehr/.eslintrc
@@ -10,7 +10,7 @@
     "ecmaFeatures": {
       "jsx": true
     }
-  },  
+  },
   "settings": {
     "import/resolver": {
       "node": {
@@ -40,7 +40,7 @@
     ],
     "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0,
+    "import/no-unresolved": 2,
     "import/prefer-default-export": 0,
     "import/no-named-as-default": 0,
     "jsx-boolean-value": 0,
@@ -98,7 +98,7 @@
     "react/jsx-no-target-blank": "error",
     "react/jsx-pascal-case": "error",
     "react/jsx-sort-props": "error",
-    "react/state-in-constructor": "off",    
+    "react/state-in-constructor": "off",
     "react/destructuring-assignment": "off",
   },
   "overrides": [


### PR DESCRIPTION
#### Rationale
Enforcing case sensitivity to prevent issues caused by how different build environments handle case differences in file paths.

#### Related Pull Requests
none

#### Changes
.eslintrc config change
