### PR TITLE
Added snprc_ehr missing trigger scripts

### DIFF
--- a/snprc_ehr/resources/queries/study/BehaviorNotification.js
+++ b/snprc_ehr/resources/queries/study/BehaviorNotification.js
@@ -1,0 +1,1 @@
+require("ehr/triggers").initScript(this);

--- a/snprc_ehr/resources/queries/study/ExpAssayHistory.js
+++ b/snprc_ehr/resources/queries/study/ExpAssayHistory.js
@@ -1,0 +1,1 @@
+require("ehr/triggers").initScript(this);

--- a/snprc_ehr/resources/queries/study/ExpBloodProducts.js
+++ b/snprc_ehr/resources/queries/study/ExpBloodProducts.js
@@ -1,0 +1,1 @@
+require("ehr/triggers").initScript(this);

--- a/snprc_ehr/resources/queries/study/ExpExposureHistory.js
+++ b/snprc_ehr/resources/queries/study/ExpExposureHistory.js
@@ -1,0 +1,1 @@
+require("ehr/triggers").initScript(this);

--- a/snprc_ehr/resources/queries/study/ExpProcedureHistory.js
+++ b/snprc_ehr/resources/queries/study/ExpProcedureHistory.js
@@ -1,0 +1,1 @@
+require("ehr/triggers").initScript(this);

--- a/snprc_ehr/resources/queries/study/ExpResearchTreatments.js
+++ b/snprc_ehr/resources/queries/study/ExpResearchTreatments.js
@@ -1,0 +1,1 @@
+require("ehr/triggers").initScript(this);

--- a/snprc_ehr/resources/queries/study/ExpVaccines.js
+++ b/snprc_ehr/resources/queries/study/ExpVaccines.js
@@ -1,0 +1,1 @@
+require("ehr/triggers").initScript(this);


### PR DESCRIPTION
#### Rationale
Trigger scripts are used to perform the ID transformation (trim leading white space) on SNPRC animal IDs.

#### Related Pull Requests
none

#### Changes
Added missing trigger scripts for various study datasets.