### PR TITLE
missing objectid workaround for snd.events

### DIFF
--- a/snprc_ehr/resources/queries/snd/Events.js
+++ b/snprc_ehr/resources/queries/snd/Events.js
@@ -1,1 +1,11 @@
+var LABKEY = require("labkey");
 require("ehr/triggers").initScript(this);
+
+function onInsert(helper, scriptErrors, row) {
+    if (helper.isETL()) {
+        row.QcState = EHR.Server.Security.getQCStateByLabel("Completed");
+    }
+    // add objectid if it is missing
+    row.ObjectId = row.ObjectId || LABKEY.Utils.generateUUID().toUpperCase();
+};
+


### PR DESCRIPTION
#### Rationale
ObjectId is a required field in snd.events - need to add it in trigger script if it doesn't exist

