### PR TITLE
Remove un-approved protocols from IACUC selection list

### DIFF
--- a/snprc_ehr/src/client/NewAnimalPage/api/fetchProtocols.js
+++ b/snprc_ehr/src/client/NewAnimalPage/api/fetchProtocols.js
@@ -15,7 +15,8 @@ const fetchProtocols = species => {
             columns: ['Iacuc', 'DisplayValue', 'Species', 'MaxAnimals'],
             filterArray: [
                 Filter.create('Species', species, Filter.Types.EQUAL),
-                Filter.create('EndDate', null, Filter.Types.MISSING)
+                Filter.create('EndDate', null, Filter.Types.MISSING),
+                Filter.create('ApprovalDate', null, Filter.Types.NOT_MISSING)
             ],
             sort: 'ProjectType, SequenceNumber'
         }).then(({ rows }) => {


### PR DESCRIPTION
#### Rationale
Remove un-approved protocols from IACUC selection list 

#### Related Pull Requests

#### Changes
Added ApprovalDate filter to fetchProtocols API
