### PR TITLE
Update SNPRC_schedulerTest.java

### DIFF
--- a/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
+++ b/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
@@ -210,7 +210,7 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
         }
         else // no access - assume 403
         {
-            clickButton("Stop Impersonating");
+            stopImpersonating();
         }
     }
 
@@ -232,7 +232,7 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
         }
         else // no access - assume 403
         {
-            clickButton("Stop Impersonating");
+            stopImpersonating();
         }
     }
 
@@ -244,7 +244,7 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
         BeginPage.beginAt(this, getProjectName());
         assertEquals("Invalid user has access to Begin.view", 403, getResponseCode());
 
-        clickButton("Stop Impersonating");
+        stopImpersonating();
     }
 
 


### PR DESCRIPTION
#### Rationale
Updated error pages don't give immediate option to stop impersonating.  Easier to click stop impersonating on page header.


#### Changes
- Use stopImpersonating() in tests
