### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/snprc_ehr/build.gradle
+++ b/snprc_ehr/build.gradle
@@ -9,6 +9,11 @@ dependencies
             implementation "commons-lang:commons-lang:${commonsLangVersion}"
             BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
 
+            BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+            BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
+            BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
+            BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:snd", depProjectConfig: "published", depExtension: "module")
+
         }
 
 task('metadataStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset metadata") {

--- a/snprc_ehr/module.properties
+++ b/snprc_ehr/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.snprc_ehr.SNPRC_EHRModule
-ModuleDependencies: LDK, EHR, SND, DataIntegration
 SupportedDatabases: mssql
 ManageVersion: true
 License: Apache 2.0

--- a/snprc_genetics/build.gradle
+++ b/snprc_genetics/build.gradle
@@ -17,6 +17,10 @@ dependencies {
     transformImplementation "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
     transformImplementation "com.google.guava:guava:${guavaVersion}"
     transformImplementation "org.apache.commons:commons-collections4:${commonsCollections4Version}"
+
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:snprcEHRModules:snprc_ehr", depProjectConfig: "published", depExtension: "module")
+
 }
 
 configurations {

--- a/snprc_genetics/module.properties
+++ b/snprc_genetics/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.snprc_genetics.SNPRC_GeneticsModule
-ModuleDependencies: SNPRC_EHR, Laboratory
 SupportedDatabases: mssql
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/snprc_scheduler/build.gradle
+++ b/snprc_scheduler/build.gradle
@@ -5,5 +5,10 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:snd", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:snd", depProjectConfig: "published", depExtension: "module")
+
 }
 

--- a/snprc_scheduler/module.properties
+++ b/snprc_scheduler/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.snprc_scheduler.SNPRC_schedulerModule
-ModuleDependencies: SND, EHR, LDK
 Label: SNPRC EHR Procedure scheduling module
 Description: The SNPRC scheduler provides timeline and procedure scheduling for snprc_ehr module.
 SupportedDatabases: mssql


### PR DESCRIPTION
#### Rationale
If a module takes a dependency on another module's jar file, we want to also declare a dependency on the module file so when not building everything from source we'll bring in the requisite modules and their jar files to the distribution.  Only in the rare case where we depend on an API jar and also check for the existence of corresponding module will we not also include the module dependency, and in that case we would declare the dependency on the jar file using the `labkey` configuration so the jar file will get copied to the `lib` directory of the module declaring the dependency and thus be available without the module.

We have also deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Move module dependency declarations from `module.properties` files to `build.gradle` files