### PR TITLE
Add PkgId to TimelineItems

### DIFF
--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
@@ -102,7 +102,6 @@ public class SNPRC_schedulerController extends SpringActionController
     @RequiresPermission(SNPRC_schedulerReadersPermission.class)
     public class getScheduledTimelinesForSpeciesAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
-
         @Override
         public ApiResponse execute(SimpleApiJsonForm form, BindException errors)
         {
@@ -110,12 +109,7 @@ public class SNPRC_schedulerController extends SpringActionController
             Date date;
 
             ActionURL url = getViewContext().getActionURL();
-
-
-
-
             Map<String, Object> props = new HashMap<>();
-
 
             List<JSONObject> timelines;
             if (isNotBlank(url.getParameter("species")) && isNotBlank(url.getParameter("date")) )

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
@@ -104,7 +104,6 @@ public class SNPRC_schedulerManager
     // TODO: fb_snprc_edit
     public List<TimelineItem> getTimelineItems(Container c, User u, String timelineObjectId, @Nullable Date scheduleDate) throws ApiUsageException
     {
-
         List<TimelineItem> timelineItems;
         try
         {
@@ -117,6 +116,7 @@ public class SNPRC_schedulerManager
             {
                 filter.addCondition(FieldKey.fromParts(TimelineItem.TIMELINEITEM_SCHEDULE_DATE), scheduleDate, CompareType.DATE_EQUAL);
             }
+
             timelineItems = new TableSelector(timelineItemTable, filter, null).getArrayList(TimelineItem.class);
 
         }
@@ -216,7 +216,6 @@ public class SNPRC_schedulerManager
 
     public List<TimelineProjectItem> getTimelineProjectItems(Container c, User u, String timelineObjectId, @Nullable List<TimelineItem> timelineItems) throws ApiUsageException
     {
-
         List<TimelineProjectItem> timelineProjectItems;
         try
         {
@@ -234,7 +233,6 @@ public class SNPRC_schedulerManager
                 filter.addInClause(FieldKey.fromParts(TimelineProjectItem.TIMELINE_PROJECT_ITEM_PROJECT_ITEM_ID), projectItemIds );
 
             }
-
              timelineProjectItems = new TableSelector(timelineProjectItemTable, filter, null).getArrayList(TimelineProjectItem.class);
         }
         catch (Exception e)

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/TimelineItem.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/TimelineItem.java
@@ -27,6 +27,7 @@ public class TimelineItem
     private String _objectId;
     private Boolean _isDeleted; // NOTE WELL: The deleteFlag set to true signals deletion of the individual TimelineItem record.
     private Boolean _isDirty;    // NOTE WELL: is set to true if the record has been updated
+    private Integer _pkgId;     // Expression column
 
 
     public static final String TIMELINEITEM_TIMELINE_ITEM_ID = "TimelineItemId";
@@ -37,6 +38,7 @@ public class TimelineItem
     public static final String TIMELINEITEM_OBJECT_ID = "ObjectId";
     public static final String TIMELINEITEM_IS_DELETED = "IsDeleted";
     public static final String TIMELINEITEM_IS_DIRTY = "IsDirty";
+    public static final String TIMELINEITEM_PKG_ID = "PkgId";
 
 
     public TimelineItem()
@@ -59,6 +61,7 @@ public class TimelineItem
             this.setObjectId(json.has(TIMELINEITEM_OBJECT_ID) && !json.isNull(TIMELINEITEM_OBJECT_ID) ? json.getString(TIMELINEITEM_OBJECT_ID) : null);
             this.setDeleted(json.has(TIMELINEITEM_IS_DELETED) && !json.isNull(TIMELINEITEM_IS_DELETED) && json.getBoolean(TIMELINEITEM_IS_DELETED));
             this.setDirty(json.has(TIMELINEITEM_IS_DIRTY) && !json.isNull(TIMELINEITEM_IS_DIRTY) && json.getBoolean(TIMELINEITEM_IS_DIRTY));
+            this.setPkgId(json.has(TIMELINEITEM_PKG_ID) && !json.isNull(TIMELINEITEM_PKG_ID) ? json.getInt(TIMELINEITEM_PKG_ID) : null);
 
             String scheduleDateString = json.has(TIMELINEITEM_SCHEDULE_DATE) && !json.isNull(TIMELINEITEM_SCHEDULE_DATE) ? json.getString(TIMELINEITEM_SCHEDULE_DATE) : null;
 
@@ -179,6 +182,16 @@ public class TimelineItem
         _isDirty = dirty;
     }
 
+    public Integer getPkgId()
+    {
+        return _pkgId;
+    }
+
+    public void setPkgId(Integer pkgId)
+    {
+        _pkgId = pkgId;
+    }
+
     @NotNull
     public Map<String, Object> toMap(Container c)
     {
@@ -191,6 +204,7 @@ public class TimelineItem
         values.put(TIMELINEITEM_OBJECT_ID, getObjectId());
         values.put(TIMELINEITEM_IS_DELETED, getDeleted());
         values.put(TIMELINEITEM_IS_DIRTY, getDirty());
+        values.put(TIMELINEITEM_PKG_ID, getPkgId());
 
         return values;
     }
@@ -211,6 +225,7 @@ public class TimelineItem
         json.put(TIMELINEITEM_OBJECT_ID, getObjectId());
         json.put(TIMELINEITEM_IS_DELETED, getDeleted());
         json.put(TIMELINEITEM_IS_DIRTY, getDirty());
+        json.put(TIMELINEITEM_PKG_ID, getPkgId());
         return json;
     }
 
@@ -227,12 +242,13 @@ public class TimelineItem
                 Objects.equals(_scheduleDate, that._scheduleDate) &&
                 Objects.equals(_objectId, that._objectId) &&
                 Objects.equals(_isDeleted, that._isDeleted) &&
+                Objects.equals(_pkgId, that._pkgId) &&
                 Objects.equals(_isDirty, that._isDirty);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(_timelineItemId, _timelineObjectId, _projectItemId, _studyDay, _scheduleDate, _objectId, _isDeleted, _isDirty);
+        return Objects.hash(_timelineItemId, _timelineObjectId, _projectItemId, _studyDay, _scheduleDate, _objectId, _isDeleted, _isDirty, _pkgId);
     }
 }

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineItemTable.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineItemTable.java
@@ -3,7 +3,10 @@ package org.labkey.snprc_scheduler.query;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
@@ -12,6 +15,7 @@ import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.snprc_scheduler.SNPRC_schedulerUserSchema;
+import org.labkey.snprc_scheduler.domains.TimelineItem;
 
 import java.sql.SQLException;
 import java.util.Map;
@@ -37,7 +41,14 @@ public class TimelineItemTable extends SimpleUserSchema.SimpleTable<SNPRC_schedu
     {
         super.init();
 
-        // initialize virtual columns here
+        SQLFragment pkgIdSql = new SQLFragment();
+
+        pkgIdSql.append("(SELECT p.PkgId as PkgId FROM snd.ProjectItems as pi");
+        pkgIdSql.append(" JOIN snd.SuperPkgs as sp ON pi.SuperPkgId = sp.SuperPkgId");
+        pkgIdSql.append(" JOIN snd.Pkgs AS p ON p.PkgId = sp.PkgId");
+        pkgIdSql.append(" WHERE " + ExprColumn.STR_TABLE_ALIAS + ".ProjectItemId = pi.ProjectItemId )");
+        ExprColumn pkgIdCol = new ExprColumn(this, TimelineItem.TIMELINEITEM_PKG_ID, pkgIdSql, JdbcType.INTEGER);
+        addColumn(pkgIdCol);
 
         return this;
     }

--- a/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
+++ b/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
@@ -202,16 +202,7 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
         int responseCode = getResponseCode();
 
         assertEquals("SNPRC_schedulerReaderRole doesn't have access to Begin.view", 200, responseCode);
-
-        if (responseCode == 200)
-        {
-            page.beginPage_Tests();
-            stopImpersonating();
-        }
-        else // no access - assume 403
-        {
-            stopImpersonating();
-        }
+        stopImpersonating();
     }
 
     @Test
@@ -225,15 +216,8 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
         int responseCode = getResponseCode();
 
         assertEquals("SNPRC_schedulerEditorRole doesn't have access to Begin.view", 200, responseCode);
-        if (responseCode == 200)
-        {
-            page.beginPage_Tests();
-            stopImpersonating();
-        }
-        else // no access - assume 403
-        {
-            stopImpersonating();
-        }
+        stopImpersonating();
+
     }
 
     @Test
@@ -243,7 +227,6 @@ public class SNPRC_schedulerTest extends BaseWebDriverTest implements Javascript
         // Verify React page does not render for non-special user roles
         BeginPage.beginAt(this, getProjectName());
         assertEquals("Invalid user has access to Begin.view", 403, getResponseCode());
-
         stopImpersonating();
     }
 


### PR DESCRIPTION
#### Rationale
PkgId is needed in TimelineItem json returned by getScheduledTimelinesForSpeciesAction.

#### Related Pull Requests
none

#### Changes
1. added PkgId as an Expression Column in TimelineItems
2. added PkgId to Timeline domain
3. code cleanup
4. refactored selenium tests to reflect changes to the new error page
