### PR TITLE
Generate webpack output in gen directory for better build caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,14 @@ kinship
 assaydata
 /snprc_ehr/resources/referenceStudy/kinship.txt
 snprc_scheduler/resources/web/snprc_scheduler/app/app.js
+snprc_scheduler/resources/web/snprc_scheduler/gen
 /snprc_ehr/resources/referenceStudy/*.log
 app
 /snprc_scheduler/resources/web/snprc_scheduler/app
-snprc_scheduler/resources/web/snprc_scheduler/app/app.js
 *.iml
 *packageExport*.snd.xml
 snprc_ehr/.gradle
+snprc_ehr/resources/views/gen
 snprc_ehr/resources/views/HelloApp*.*
 snprc_ehr/resources/views/helloWorld*.*
 snprc_ehr/resources/views/NewAnimalPage*.*
@@ -28,7 +29,6 @@ snprc_mobile
 snprc_ehr.2020*.zip
 snprc_ehr.2020*.7z
 snprc_ehr/.editorconfig
-snprc_ehr/cmd-here.exe
 snprc_ehr/resources/referenceStudy/LoadTaqmanData
 snprc_ehr/resources/referenceStudy/datasetImport/LoadTaqmanData
 snprc_scheduler/.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ app
 snprc_scheduler/resources/web/snprc_scheduler/app/app.js
 *.iml
 *packageExport*.snd.xml
+snprc_ehr/.gradle
 snprc_ehr/resources/views/HelloApp*.*
 snprc_ehr/resources/views/helloWorld*.*
 snprc_ehr/resources/views/NewAnimalPage*.*
@@ -30,3 +31,4 @@ snprc_ehr/.editorconfig
 snprc_ehr/cmd-here.exe
 snprc_ehr/resources/referenceStudy/LoadTaqmanData
 snprc_ehr/resources/referenceStudy/datasetImport/LoadTaqmanData
+snprc_scheduler/.gradle

--- a/snprc_ehr/package.json
+++ b/snprc_ehr/package.json
@@ -29,7 +29,7 @@
       }
     },
     "clean": {
-      "command": "rimraf resources/web/snprc_ehr/gen"
+      "command": "rimraf resources/web/snprc_ehr/gen && rimraf resources/views/gen"
     },
     "build:jest-teamcity": {
       "command": "jest --testResultsProcessor=jest-teamcity-reporter",

--- a/snprc_ehr/webpack/prod.config.js
+++ b/snprc_ehr/webpack/prod.config.js
@@ -22,12 +22,12 @@ for (let i = 0; i < entryPoints.apps.length; i++) {
             name: entryPoint.name,
             title: entryPoint.title,
             permission: entryPoint.permission,
-            filename: '../../../views/' + entryPoint.name + '.view.xml',
+            filename: '../../../views/gen/' + entryPoint.name + '.view.xml',
             template: 'webpack/app.view.template.xml'
         }),
         new HtmlWebpackPlugin({
             inject: false,
-            filename: '../../../views/' + entryPoint.name + '.html',
+            filename: '../../../views/gen/' + entryPoint.name + '.html',
             template: 'webpack/app.template.html'
         }),
         new HtmlWebpackPlugin({
@@ -36,14 +36,14 @@ for (let i = 0; i < entryPoints.apps.length; i++) {
             name: entryPoint.name,
             title: entryPoint.title,
             permission: entryPoint.permission,
-            filename: '../../../views/' + entryPoint.name + 'Dev.view.xml',
+            filename: '../../../views/gen/' + entryPoint.name + 'Dev.view.xml',
             template: 'webpack/app.view.template.xml'
         }),
         new HtmlWebpackPlugin({
             inject: false,
             mode: 'dev',
             name: entryPoint.name,
-            filename: '../../../views/' + entryPoint.name + 'Dev.html',
+            filename: '../../../views/gen/' + entryPoint.name + 'Dev.html',
             template: 'webpack/app.template.html'
         })
     ]);

--- a/snprc_scheduler/package.json
+++ b/snprc_scheduler/package.json
@@ -14,7 +14,7 @@
   },
   "betterScripts": {
     "clean": {
-      "command": "rimraf resources/web/snprc_scheduler/app"
+      "command": "rimraf resources/web/snprc_scheduler/app && rimraf resources/web/snprc_scheduler/gen"
     },
     "build:jest-test": {
       "command": "jest --config=jest.config.json",

--- a/snprc_scheduler/resources/views/app.html
+++ b/snprc_scheduler/resources/views/app.html
@@ -1,2 +1,2 @@
 <div id="app" class='App'></div>
-<script src="/labkey/snprc_scheduler/app/app.js" type="application/javascript"></script>
+<script src="/labkey/snprc_scheduler/gen/app/app.js" type="application/javascript"></script>

--- a/snprc_scheduler/resources/views/app.view.xml
+++ b/snprc_scheduler/resources/views/app.view.xml
@@ -3,6 +3,6 @@
         <permission name="login"/>
     </permissions>
     <dependencies>
-        <dependency path="snprc_scheduler/app/app.css"/>
+        <dependency path="snprc_scheduler/gen/app/app.css"/>
     </dependencies>
 </view>

--- a/snprc_scheduler/resources/views/appDev.html
+++ b/snprc_scheduler/resources/views/appDev.html
@@ -1,3 +1,3 @@
 <div id="app"></div>
-<link href="<%=contextPath%>/snprc_scheduler/app/app.css" rel="stylesheet">
+<link href="<%=contextPath%>/snprc_scheduler/gen/app/app.css" rel="stylesheet">
 <script src="http://localhost:3000/app.js"></script>

--- a/snprc_scheduler/webpack/prod.config.js
+++ b/snprc_scheduler/webpack/prod.config.js
@@ -17,7 +17,7 @@ module.exports = {
     },
 
     output: {
-        path: path.resolve(__dirname, '../resources/web/snprc_scheduler/app/'),
+        path: path.resolve(__dirname, '../resources/web/snprc_scheduler/gen/app/'),
         publicPath: './', // allows context path to resolve in both js/css
         filename: "[name].js"
     },


### PR DESCRIPTION
#### Rationale
For optimal use of the Gradle build cache, we need to generate webpack output into a dedicated directory.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/98

#### Changes
* Update webpack build into `gen` directory
* Adjust npm `clean` task to clean out `gen` directory