### PR TITLE
Fb serial ap ifix

### DIFF
--- a/snprc_ehr/src/client/ChipReader/constants/index.js
+++ b/snprc_ehr/src/client/ChipReader/constants/index.js
@@ -1,26 +1,24 @@
 export default {
     debug: false,
-    notSupportedMessage: `Sorry, Serial.API is not supported on this device, make sure you're 
+    notSupportedMessage: `Sorry, Serial.API is not supported on this device, make sure you're
     running Chrome 78 or later and have enabled the #enable-experimental-web-platform-features flag in
     chrome://flags`,
     timeOutErrorMessage: 'Chip reader is not responding. Ensure you are connected to the correct port, and the reader is turned on.',
-    validSerialOptions: [ 'baudrate', 'databits', 'stopbits', 'parity', 'buffersize', 'rtscts', 'xon', 'xoff', 'xany' ],
+    validSerialOptions: [ 'baudRate', 'dataBits', 'stopBits', 'parity', 'bufferSize', 'flowControl'],
     defaultSerialOptions: {
-        baudrate: 19200,
-        databits: 8,
-        stopbits: 1,
-        buffersize: 255,
+        baudRate: 19200,
+        dataBits: 8,
+        stopBits: 1,
+        bufferSize: 255,
         parity: 'none',
-        rctscts: false,
-        xon: true,
-        xoff: true,
-        xany: false
+        flowControl: 'none'
     }
 }
 
-// https://wicg.github.io/serial/#dom-serial
+// https://wicg.github.io/serial/#dom-serial or https://reillyeon.github.io/serial/#dom-serialoptions
 // parity is an enum:   "none",  "even",  "odd",  "mark",  "space"
 // baudrate member: One of 115200, 57600, 38400, 19200, 9600, 4800, 2400, 1800, 1200, 600, 300, 200, 150, 134, 110, 75, or 50.
 // databits member: One of 8, 7, 6, or 5.
 // stopbits member: One of 1 or 2.
-// rctscts, xon, xoff, xany: boolean
+// rctscts, xon, xoff, xany: boolean - stopped working in Chrome ver. 86 - switched to 'flowControl'
+// property names switched to camelCase in Chrome ver. 86  Arrrrg

--- a/snprc_ehr/src/client/ChipReader/tests/__snapshots__/ChipReader.test.jsx.snap
+++ b/snprc_ehr/src/client/ChipReader/tests/__snapshots__/ChipReader.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`ChipReader tests Should render the landing page with no serial support 
     errorMessages={
       Array [
         Object {
-          "colName": "Sorry, Serial.API is not supported on this device, make sure you're 
+          "colName": "Sorry, Serial.API is not supported on this device, make sure you're
     running Chrome 78 or later and have enabled the #enable-experimental-web-platform-features flag in
     chrome://flags",
           "propTest": true,
@@ -56,15 +56,12 @@ exports[`ChipReader tests Should render the landing page without error message. 
           handleSetConnection={[Function]}
           serialOptions={
             Object {
-              "baudrate": 19200,
-              "buffersize": 255,
-              "databits": 8,
+              "baudRate": 19200,
+              "bufferSize": 255,
+              "dataBits": 8,
+              "flowControl": "none",
               "parity": "none",
-              "rctscts": false,
-              "stopbits": 1,
-              "xany": false,
-              "xoff": true,
-              "xon": true,
+              "stopBits": 1,
             }
           }
         />


### PR DESCRIPTION
#### Rationale
Starting with Chrome 86, Google changed the property names in the Serial API configuration to camelCase and deprecate some configuration options.

#### Related Pull Requests
None

#### Changes
Google changed the property names in the Serial API configuration to camelCase and deprecate some configuration options. In Chrome 78-85 the configuration was:
    defaultSerialOptions: {
        baudrate: 19200,
        databits: 8,
        stopbits: 1,
        buffersize: 255,
        parity: 'none',
        rctscts: false,
        xon: true,
        xoff: true,
        xany: false
    }

Starting with Chrome version 86, It is now:
    defaultSerialOptions: {
        baudRate: 19200,
        dataBits: 8,
        stopBits: 1,
        bufferSize: 255,
        parity: 'none',
        flowControl: 'none'
    }
The API was expecting {baudRate: 19200} and getting {baudrate: 19200}. 

