### PR TITLE
Catching feature branch up with develop (#332)

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,0 +1,26 @@
+---
+# Workflow to validate Pull Request branches
+name: PR Validation
+
+# Trigger on PR creation
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  validate_pr:
+    if: github.event.pull_request.head.repo.owner.login == 'LabKey'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate PR Branches
+        uses: labkey-tchad/gitHubActions/validate-pr@master
+        with:
+          pr_base: ${{ github.event.pull_request.base.ref }}
+          pr_head: ${{ github.event.pull_request.head.ref }}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_title: ${{ github.event.pull_request.title }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/snprc_ehr/src/client/ChipReader/ChipReader.jsx
+++ b/snprc_ehr/src/client/ChipReader/ChipReader.jsx
@@ -17,6 +17,7 @@ export default class ChipReader extends React.Component {
     debug = constants.debug;
     isSerialSupported = ('serial' in navigator) || this.props.debug
     previousChipId = undefined
+
     componentDidMount() {
         window.addEventListener('beforeunload', this.beforeunload.bind(this))
 
@@ -28,16 +29,16 @@ export default class ChipReader extends React.Component {
             }
         ))
     }
+
     componentWillUnmount() {
         window.removeEventListener('beforeunload', this.beforeunload.bind(this))
     }
+
     beforeunload(e) {
-        if (this.state.connection) {
+        if (this.state.connection) 
             close(this.state.connection)
-            e.preventDefault()
-            e.returnValue = true
-        }
     }
+
     handleSetConnection = connection => {
         this.setState(prevState => (
             {
@@ -46,12 +47,11 @@ export default class ChipReader extends React.Component {
             }
         ))
     }
+
     handleDataChange = async value => {
         const data = value || { chipId: undefined, animalId: undefined, temperature: undefined }
-
         if (!data.chipId || data.chipId === this.previousChipId) return
 
-        // console.log(`chipId = ${data.chipId}`)
         this.previousChipId = data.chipId
 
         if (data.chipId && !data.animalId) {
@@ -69,6 +69,7 @@ export default class ChipReader extends React.Component {
             ...prevState,
             chipData: data,
             ...(data.animalId && { errorMessage: undefined }), // clear error message
+            ...((!data.animalId.value || data.animalId.value === 'Not Found') && { errorMessage: 'Animal Not Found'}),
             ...(data.animalId && {
                 summaryData: [
                     ...prevState.summaryData,
@@ -77,6 +78,7 @@ export default class ChipReader extends React.Component {
             })
         }))
     }
+
     handleErrorMessage = error => {
         this.setState(prevState => (
             {
@@ -85,6 +87,7 @@ export default class ChipReader extends React.Component {
             }
         ))
     }
+
     render() {
         // allow debug mode to be triggered for running test suite
         this.debug = this.props.debug !== undefined ? this.props.debug : constants.debug

--- a/snprc_ehr/src/client/ChipReader/api/fetchAnimalId.js
+++ b/snprc_ehr/src/client/ChipReader/api/fetchAnimalId.js
@@ -2,6 +2,10 @@ import { executeSql } from '../../Shared/api/api'
 import moment from 'moment'
 
 const parse = rows => {
+    if (rows.length === 0) {
+       return [{ value: 'Not Found', url: '', location: '', time: moment()}]
+    }
+
     return rows.map(({ data }) => {
         return { value: data.Id.value, url: data.Id.url, location: data.location.value, time: moment() }
     })

--- a/snprc_ehr/src/client/ChipReader/components/ChipDataPanel.jsx
+++ b/snprc_ehr/src/client/ChipReader/components/ChipDataPanel.jsx
@@ -10,9 +10,11 @@ export default class ChipDataPanel extends React.Component {
         isReading: false,
         connection: undefined
     }
+
     componentDidMount = () => {
         console.log('ChipDataPanel mounted')
     }
+
     onConnectClick = () => {
         if (!this.state.connection) {
             requestPort().then(serialPort => connect(serialPort, this.props.serialOptions).then(connection => {
@@ -23,7 +25,9 @@ export default class ChipDataPanel extends React.Component {
             })
         }
     }
+
     flushPromises = () => { return new Promise(resolve => setImmediate(resolve)) }
+
     onStartClick = async () => {
         if (this.state.connection && !this.state.isReading) {
             this.setState(prevState => (
@@ -62,6 +66,7 @@ export default class ChipDataPanel extends React.Component {
             })
         }
     }
+
     onQuitClick = () => {
         // close serial connection
         if (this.state.connection) {
@@ -79,11 +84,13 @@ export default class ChipDataPanel extends React.Component {
             })
         }
     }
-    handleChange = () => { /* lint fix */ }
-    render() {
-        this.state.connection = this.props.connection && this.props.connection
 
-        const { chipId, animalId, temperature } = this.props.chipData && this.props.chipData
+    handleChange = () => { /* lint fix */ }
+
+    render() {
+        this.state.connection = this.props.connection //&& this.props.connection
+
+        const { chipId, animalId, temperature } = this.props.chipData //&& this.props.chipData
 
         return (
           <>

--- a/snprc_ehr/src/client/ChipReader/components/SummaryGridItem.jsx
+++ b/snprc_ehr/src/client/ChipReader/components/SummaryGridItem.jsx
@@ -7,11 +7,13 @@ export default class SummaryGridItem extends React.PureComponent {
     this.props.print(id)
   }
   onClick = () => {
-    const fullPath = this.props.row.animalId.url
-    const left = window.screenX + 20
+    if (this.props.row.animalId.url) {
+      const fullPath = this.props.row.animalId.url
+      const left = window.screenX + 20
 
-    // window.open(fullPath, '_blank', `location=yes,height=1024,width=1500,status=no,scrollbars=yes,menubar=yes,left=${left}`)
-    window.open(fullPath, '_blank', `height=1024,width=1500,left=${left}`)
+      // window.open(fullPath, '_blank', `location=yes,height=1024,width=1500,status=no,scrollbars=yes,menubar=yes,left=${left}`)
+      window.open(fullPath, '_blank', `height=1024,width=1500,left=${left}`)
+    }
   }
   render() {
     const { animalId, chipId, temperature } = this.props.row

--- a/snprc_ehr/src/client/ChipReader/components/SummaryGridPanel.jsx
+++ b/snprc_ehr/src/client/ChipReader/components/SummaryGridPanel.jsx
@@ -22,10 +22,10 @@ export default class SummaryGridPanel extends React.PureComponent {
             </thead>
             <tbody>
               { this.props.summaryData.length === 0 && <tr><td colSpan="5"> No animals </td></tr> }
-              { this.props.summaryData.length > 0 && this.props.summaryData.map(row => {
+              { this.props.summaryData.length > 0 && this.props.summaryData.slice(0).reverse().map(row => {
                 return (
                   <SummaryGridItem
-                    key={ `${row.animalId.value}.${Math.floor((Math.random() * 10000)).toString()} ` }
+                    key={ `${row.chipId}.${Math.floor((Math.random() * 10000)).toString()} ` }
                     row={ row }
                   />
                 )

--- a/snprc_ehr/src/client/ChipReader/constants/index.js
+++ b/snprc_ehr/src/client/ChipReader/constants/index.js
@@ -1,26 +1,25 @@
 export default {
     debug: false,
-    notSupportedMessage: `Sorry, Serial.API is not supported on this device, make sure you're 
+    notSupportedMessage: `Sorry, Serial.API is not supported on this device, make sure you're
     running Chrome 78 or later and have enabled the #enable-experimental-web-platform-features flag in
     chrome://flags`,
     timeOutErrorMessage: 'Chip reader is not responding. Ensure you are connected to the correct port, and the reader is turned on.',
-    validSerialOptions: [ 'baudrate', 'databits', 'stopbits', 'parity', 'buffersize', 'rtscts', 'xon', 'xoff', 'xany' ],
+    validSerialOptions: [ 'baudRate', 'dataBits', 'stopBits', 'parity', 'bufferSize', 'flowControl'],
+    readTimeout: 3000, // 3300 milliseconds
     defaultSerialOptions: {
-        baudrate: 19200,
-        databits: 8,
-        stopbits: 1,
-        buffersize: 255,
+        baudRate: 19200,
+        dataBits: 8,
+        stopBits: 1,
+        bufferSize: 255,
         parity: 'none',
-        rctscts: false,
-        xon: true,
-        xoff: true,
-        xany: false
+        flowControl: 'none'
     }
 }
 
-// https://wicg.github.io/serial/#dom-serial
+// https://wicg.github.io/serial/#dom-serial or https://reillyeon.github.io/serial/#dom-serialoptions
 // parity is an enum:   "none",  "even",  "odd",  "mark",  "space"
 // baudrate member: One of 115200, 57600, 38400, 19200, 9600, 4800, 2400, 1800, 1200, 600, 300, 200, 150, 134, 110, 75, or 50.
 // databits member: One of 8, 7, 6, or 5.
 // stopbits member: One of 1 or 2.
-// rctscts, xon, xoff, xany: boolean
+// rctscts, xon, xoff, xany: boolean - stopped working in Chrome ver. 86 - switched to 'flowControl'
+// property names switched to camelCase in Chrome ver. 86  Arrrrg

--- a/snprc_ehr/src/client/ChipReader/styles/chipReader.scss
+++ b/snprc_ehr/src/client/ChipReader/styles/chipReader.scss
@@ -29,5 +29,6 @@
  .id-table-scroll {
     overflow-y: auto;
     min-height: 24.5rem;
+    max-height: 50rem;
     padding: 0, 0.1rem !important;
 }

--- a/snprc_ehr/src/client/ChipReader/tests/__snapshots__/ChipReader.test.jsx.snap
+++ b/snprc_ehr/src/client/ChipReader/tests/__snapshots__/ChipReader.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`ChipReader tests Should render the landing page with no serial support 
     errorMessages={
       Array [
         Object {
-          "colName": "Sorry, Serial.API is not supported on this device, make sure you're 
+          "colName": "Sorry, Serial.API is not supported on this device, make sure you're
     running Chrome 78 or later and have enabled the #enable-experimental-web-platform-features flag in
     chrome://flags",
           "propTest": true,
@@ -56,15 +56,12 @@ exports[`ChipReader tests Should render the landing page without error message. 
           handleSetConnection={[Function]}
           serialOptions={
             Object {
-              "baudrate": 19200,
-              "buffersize": 255,
-              "databits": 8,
+              "baudRate": 19200,
+              "bufferSize": 255,
+              "dataBits": 8,
+              "flowControl": "none",
               "parity": "none",
-              "rctscts": false,
-              "stopbits": 1,
-              "xany": false,
-              "xoff": true,
-              "xon": true,
+              "stopBits": 1,
             }
           }
         />

--- a/snprc_ehr/src/client/ChipReader/tests/components/__snapshots__/SummaryGridPanel.test.jsx.snap
+++ b/snprc_ehr/src/client/ChipReader/tests/components/__snapshots__/SummaryGridPanel.test.jsx.snap
@@ -34,22 +34,22 @@ exports[`SummaryGridPanel tests Should render empty SummaryGridPanel. 1`] = `
       </thead>
       <tbody>
         <SummaryGridItem
-          key="12345.5000 "
+          key="3C45433F.5000 "
           row={
             Object {
               "animalId": Object {
                 "location": "2.00-42",
-                "time": "2020-08-18T16:47:44.704Z",
-                "url": "/labkey/ehr/SNPRC/participantView.view?participantId=12345",
-                "value": "12345",
+                "time": "2020-08-18T16:49:56.729Z",
+                "url": "/labkey/ehr/SNPRC/participantView.view?participantId=22222",
+                "value": "22222",
               },
-              "chipId": "1C45433F",
-              "temperature": "<25.0",
+              "chipId": "3C45433F",
+              "temperature": "26.3",
             }
           }
         />
         <SummaryGridItem
-          key="11111.5000 "
+          key="2C45433F.5000 "
           row={
             Object {
               "animalId": Object {
@@ -64,17 +64,17 @@ exports[`SummaryGridPanel tests Should render empty SummaryGridPanel. 1`] = `
           }
         />
         <SummaryGridItem
-          key="22222.5000 "
+          key="1C45433F.5000 "
           row={
             Object {
               "animalId": Object {
                 "location": "2.00-42",
-                "time": "2020-08-18T16:49:56.729Z",
-                "url": "/labkey/ehr/SNPRC/participantView.view?participantId=22222",
-                "value": "22222",
+                "time": "2020-08-18T16:47:44.704Z",
+                "url": "/labkey/ehr/SNPRC/participantView.view?participantId=12345",
+                "value": "12345",
               },
-              "chipId": "3C45433F",
-              "temperature": "26.3",
+              "chipId": "1C45433F",
+              "temperature": "<25.0",
             }
           }
         />

--- a/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRModule.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRModule.java
@@ -119,7 +119,7 @@ public class SNPRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.013;
+        return 21.000;
     }
 
     @Override

--- a/snprc_r24/src/org/labkey/snprc_r24/snprc_r24Module.java
+++ b/snprc_r24/src/org/labkey/snprc_r24/snprc_r24Module.java
@@ -47,7 +47,7 @@ public class snprc_r24Module extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.000;
+        return 21.000;
     }
 
     @Override
@@ -89,7 +89,6 @@ public class snprc_r24Module extends DefaultModule
             });
         }
     }
-
 
     @Override
     @NotNull


### PR DESCRIPTION
* Fb serial ap ifix (#328)

* Starting with Chrome 86, Google changed the property names in the Serial API configuration to camelCase and deprecate some configuration options.

* Update snapshot

* Add PR validation workflow (#329)

* Schema bump to 21.000 (#330)

* Continuation of chip reader dev (#331)

* Continuation of chip reader dev
1. Added Chip Ids to Summary grid if animal is not found in DB lookup
2. Refactored fetchAnimalId.js to return "Not Found" record for animals not found in DB lookup
3. Moved readTimeout value to constants object
4. Removed chip data prefix (100000) from Biomark chips
5. Removed trailing commas from certain UID chips
6. Replaced TextDecoderStream() in serialService.ja with inline transformation of UInt8Array data
   - filtering for printable characters only
   - Biomark chips include "STX" (Start of Text) marker in data
7. Refactored connection close method to handle edge cases
8. Tweaked summary grid CSS
9. Updated SummaryGridPanel snapshot

* fixed typo in summaryGridItem key

* update snapshot

Co-authored-by: Trey Chadick <tchad@labkey.com>
Co-authored-by: Adam Rauch <adam@labkey.com>

#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
