### PR TITLE
Added eventId to source queries to make it easier to validate data

### DIFF
--- a/snprc_ehr/resources/source_queries/create_v_alopecia.sql
+++ b/snprc_ehr/resources/source_queries/create_v_alopecia.sql
@@ -32,13 +32,15 @@ AS
 -- Create date: 9/21/2017
 -- Description:	Selects the ETL records for LabKey study.alopecia dataset
 -- Changes:
---
+-- 1/27/2021   added eventId. tjh
 --
 -- ==========================================================================================
 
 SELECT  a.ID AS id ,
+        a.EventId,
         a.DATE_TM AS date ,
         a.alopecia AS alopeciaScore ,
+        a.scorer,
         a.OBJECT_ID AS objectid ,
         a.ENTRY_DATE_TM AS modified ,
         dbo.f_map_username(a.USER_NAME) AS modifiedby ,

--- a/snprc_ehr/resources/source_queries/create_v_tb.sql
+++ b/snprc_ehr/resources/source_queries/create_v_tb.sql
@@ -34,11 +34,13 @@ ALTER VIEW [labkey_etl].[V_TB] AS
 -- DESCRIPTION:	VIEW CONTAINS THE DATA EQUALIVENCE OF THE ORIGINAL TB TABLE for the LabKey ETL
 -- CHANGES:
 -- 11/14/2016  added modified, modifiedby, created, and createdby columns tjh
+-- 1/27/2021   added eventId. tjh
 -- ==========================================================================================
 
 SELECT
 
   ID,
+  EventId,
   TST_DATE  AS DATE,
   TB_SITE   AS SITE,
   TB_RESULT AS RESULT,
@@ -58,6 +60,7 @@ FROM
 
       SELECT
         AE.ANIMAL_ID                     AS ID,
+        AE.ANIMAL_EVENT_ID               AS EventId,
         AE.EVENT_DATE_TM                 AS TST_DATE,
         CPA.VALUE,
         CPA.ATTRIB_KEY,

--- a/snprc_ehr/resources/source_queries/create_v_vitals.sql
+++ b/snprc_ehr/resources/source_queries/create_v_vitals.sql
@@ -37,11 +37,12 @@ ALTER VIEW [labkey_etl].[V_VITALS] AS
 -- 11/15/2016  added modified, modifiedby, created, and createdby, parentid columns tjh
 -- 11/29/2016  added project column. tjh
 -- 4/25/2017   fixed created/createdby bug. tjh
---
+-- 1/27/2021   added eventId. tjh
 -- ==========================================================================================
 
 SELECT
   ID,
+  EventId,
   DATE_TM                     AS date,
   project,
   CAST(RR AS NUMERIC(4, 0))   AS respRate,
@@ -60,6 +61,7 @@ FROM
 
       SELECT
         AE.ANIMAL_ID                              AS ID,
+        AE.ANIMAL_EVENT_ID                        AS EventId,
         AE.EVENT_DATE_TM                          AS DATE_TM,
         ae.charge_id                              AS project,
         CASE WHEN ISNUMERIC(cpa.value) <> 1

--- a/snprc_ehr/resources/source_queries/create_v_weight.sql
+++ b/snprc_ehr/resources/source_queries/create_v_weight.sql
@@ -36,10 +36,12 @@ ALTER VIEW [labkey_etl].[V_WEIGHT] AS
 --  11/19/2015	Changed query to use the pkg_category/valid_code_table to find weight pkg codes. tjh
 -- 11/15/2016  added modified, modifiedby, created, and createdby, parentid columns + code cleanup tjh
 -- 11/29/2016  added project column. tjh
+-- 1/27/2021   added eventId. tjh
 -- ==========================================================================================
 
 SELECT
   ae.ANIMAL_ID                     AS id,
+  ae.ANIMAL_EVENT_ID                AS EventId,
   ae.EVENT_DATE_TM                 AS date,
   CAST(cpa.VALUE AS NUMERIC(7, 4)) AS weight,
   ae.charge_id                     AS project,


### PR DESCRIPTION
#### Rationale
Added eventId to source queries to make it easier to validate data. The source queries serve as the data source to compare SND derived tables to.

#### Related Pull Requests
none

#### Changes
Addition of EventId column to source query scripts
