### PR TITLE
Unregister blood trigger script for snprc and snprc_scheduler

### DIFF
--- a/snprc_ehr/resources/scripts/snprc_triggers.js
+++ b/snprc_ehr/resources/scripts/snprc_triggers.js
@@ -36,6 +36,7 @@ exports.init = function (EHR) {
         EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'cases', EHR.Server.TriggerManager.Events.BEFORE_UPSERT);
         EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'cases', EHR.Server.TriggerManager.Events.AFTER_DELETE);
         EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'cases', EHR.Server.TriggerManager.Events.AFTER_UPSERT);
+        EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'blood', EHR.Server.TriggerManager.Events.BEFORE_UPSERT);
     });
 
 };

--- a/snprc_scheduler/resources/scripts/snprc_scheduler_triggers.js
+++ b/snprc_scheduler/resources/scripts/snprc_scheduler_triggers.js
@@ -1,0 +1,8 @@
+exports.init = function (EHR) {
+
+    EHR.Server.TriggerManager.registerHandler(EHR.Server.TriggerManager.Events.INIT, function (event, helper, EHR) {
+
+        EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'blood', EHR.Server.TriggerManager.Events.BEFORE_UPSERT);
+    });
+
+};

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
@@ -4,11 +4,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.ehr.EHRService;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.QuerySchema;
+import org.labkey.api.resource.Resource;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.snprc_scheduler.SNPRC_schedulerService;
@@ -89,6 +91,10 @@ public class SNPRC_schedulerModule extends DefaultModule
     {
         // add a container listener so we'll know when our container is deleted:
         ContainerManager.addContainerListener(new SNPRC_schedulerContainerListener());
+
+        Resource r = getModuleResource("/scripts/snprc_scheduler_triggers.js");
+        assert r != null;
+        EHRService.get().registerTriggerScript(this, r);
 
         DefaultSchema.registerProvider(SNPRC_schedulerSchema.NAME, new DefaultSchema.SchemaProvider(this)
         {


### PR DESCRIPTION
#### Rationale
Blood dataset trigger script now executes code that was not previously getting executed due to addition of DatasetUpdateService.preTriggerDataIterator() (more details in snprc pr 344 below). This is causing test failures during study import. 
Even though 21.3 branch is not used by the center, and blood dataset will be removed and tests will be refactored in 21.4, we still want to ensure that any new development in 21.3 does not cause any inadvertent failures for snprc and the tests run successfully.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2056
* https://github.com/LabKey/snprcEHRModules/pull/344

#### Changes
* Unregister blood.js/BEFORE_UPSERT for snprc and snprc_scheduler so that the snprc tests continue to run without causing issues during study import.
