### PR TITLE
Various ETL improvements

### DIFF
--- a/snprc_ehr/resources/queries/snprc_ehr/ExportNewAnimalData.sql
+++ b/snprc_ehr/resources/queries/snprc_ehr/ExportNewAnimalData.sql
@@ -19,7 +19,7 @@ SELECT
     n.BirthCode as Bd_Status,
     n.AcquisitionType,
     n.AcqDate AS AcquisitionDate,
-    n.SourceInstitutionLocation,
+    n.SourceInstitutionLocation.code as SourceInstitutionLocation,
     n.species,
     n.Gender,
     n.sire,

--- a/snprc_ehr/resources/source_queries/create_v_animal_event_narratives.sql
+++ b/snprc_ehr/resources/source_queries/create_v_animal_event_narratives.sql
@@ -13,14 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
 
 /*==============================================================*/
 /* View: V_ANIMAL_EVENT_NARRATIVES                                    */
@@ -35,6 +27,7 @@ ALTER VIEW [labkey_etl].[V_ANIMAL_EVENT_NARRATIVES] AS
 -- 12/29/2015	Terry Hawkins	renamed visitRowId column to encounterId
 -- 11/3/2016  added modified, modifiedby, created, createdby columns tjh
 -- 2/28/2017	added encounter_type column. tjh
+-- 6/28/2021    removed ParticipantSequenceNum column. tjh
 -- ==========================================================================================
 
 
@@ -42,7 +35,6 @@ SELECT
   ap.animal_event_id               AS encounterId,
   ap.animal_id                     AS id,
   ap.event_date_tm                 AS date,
-  ap.ParticipantSequenceNum,
   ap.charge_id                     AS project,
   ap.proc_narrative                AS remark,
   'procedure'                      AS encounter_type,

--- a/snprc_ehr/resources/source_queries/create_v_clinical_admissions.sql
+++ b/snprc_ehr/resources/source_queries/create_v_clinical_admissions.sql
@@ -13,35 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-/****** Object:  View [labkey_etl].[v_clinical_admissions]    Script Date: 8/14/2015 8:08:46 AM ******/
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
 
 ALTER VIEW [labkey_etl].[v_clinical_admissions] AS
 -- ==========================================================================================
 -- Author:		Terry Hawkins
 -- Create date: 6/22/2015
--- Description:	Selects the clinical admissions for LabKey study.clinical_observations dataset
--- Note: 
---		
+-- Description:	Selects the clinical admissions for LabKey study.clinical_observations dataset`
+-- Note:
+--
 -- Changes:
 -- 9/25/2015	Removed animal id from ParticipantSequenceNum. tjh
 -- 8/8/2016		added sdx, admit_complaint, resolution, and retarget vet to assignedvet column
 -- 11/10/2016  added modified, modifiedby, created, and createdby columns tjh
+-- 7/1/2021    removed ParticipantSequenceNum column. tjh
 -- ==========================================================================================
 
 
 SELECT
   c.id                             AS id,
   c.admit_date_tm                  AS date,
-  CAST(c.admit_id AS VARCHAR(128)) AS ParticipantSequenceNum,
   c.release_date_tm                AS enddate,
   c.pdx                            AS problem,
   c.sdx                            AS sdx,

--- a/snprc_ehr/resources/source_queries/create_v_delete_accounts.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_accounts.sql
@@ -13,14 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
 
 /*==============================================================*/
 /* View: V_DELETE_ACCOUNTS                                      */
@@ -32,6 +24,7 @@ ALTER VIEW [labkey_etl].[V_DELETE_ACCOUNTS] as
 -- Create date: 6/12/2015
 --
 -- 6/29/2015 renamed. tjh
+-- 7/2/2021 changed demographics data source. tjh
 -- ==========================================================================================
 SELECT 
 	aa.object_id,
@@ -39,10 +32,10 @@ SELECT
 
 FROM audit.audit_accounts AS aa
 -- select primates only from the TxBiomed colony
-INNER JOIN Labkey_etl.V_DEMOGRAPHICS AS d ON d.id = aa.id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = aa.id
 WHERE aa.AUDIT_ACTION = 'D' AND aa.OBJECT_ID IS NOT NULL
 
-go
+GO
 
 GRANT SELECT on labkey_etl.V_DELETE_ACCOUNTS to z_labkey
 GRANT SELECT ON audit.audit_accounts TO z_labkey

--- a/snprc_ehr/resources/source_queries/create_v_delete_animal_ownership.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_animal_ownership.sql
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-CREATE VIEW [labkey_etl].[V_DELETE_ANIMAL_OWNERSHIP] as
+ALTER VIEW [labkey_etl].[V_DELETE_ANIMAL_OWNERSHIP] as
 -- ====================================================================================================================
 -- Object: v_delete_animal_ownership
 -- Author:		Terry Hawkins
 -- Create date: 5/25/2016
+-- 7/2/2021 changed demographics data source. tjh
 --
 -- ==========================================================================================
 SELECT 
@@ -26,7 +27,7 @@ SELECT
 
 FROM audit.audit_animal_ownership AS aa
 -- select primates only from the TxBiomed colony
-INNER JOIN Labkey_etl.V_DEMOGRAPHICS AS d ON d.id = aa.id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = aa.id
 WHERE aa.AUDIT_ACTION = 'D' AND aa.OBJECT_ID IS NOT NULL
 
 go

--- a/snprc_ehr/resources/source_queries/create_v_delete_arc_animal_assignments.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_arc_animal_assignments.sql
@@ -13,19 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
 
-/****** Object:  View [labkey_etl].[v_delete_clinical_admissions]    Script Date: 6/26/2015 10:59:28 AM ******/
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
-
-
-CREATE VIEW [labkey_etl].[v_delete_arc_animal_assignments] AS
+ALTER VIEW [labkey_etl].[v_delete_arc_animal_assignments] AS
 -- ==========================================================================================
 -- Author:		Terry Hawkins
 -- Create date: 8/14/2015
@@ -33,6 +22,7 @@ CREATE VIEW [labkey_etl].[v_delete_arc_animal_assignments] AS
 -- Note: 
 --		
 -- Changes:
+-- 7/2/2021 changed demographics data source. tjh
 --
 -- ==========================================================================================
 
@@ -40,13 +30,10 @@ CREATE VIEW [labkey_etl].[v_delete_arc_animal_assignments] AS
 SELECT aaa.object_id AS objectid,
 	   aaa.audit_date_tm AS audit_date_tm
 
-
-
 FROM audit.audit_arc_animal_assignments AS aaa
 -- select primates only from the TxBiomed colony
-INNER JOIN Labkey_etl.V_DEMOGRAPHICS AS d ON d.id = aaa.id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = aaa.id
 WHERE aaa.audit_action = 'D' AND aaa.object_id IS NOT NULL
-
 
 GO
 

--- a/snprc_ehr/resources/source_queries/create_v_delete_arrival.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_arrival.sql
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-/****** Object:  View [labkey_etl].[V_DELETE_ARRIVAL]    Script Date: 6/25/2015 10:29:17 AM ******/
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
 
 /*==============================================================*/
 /* View: V_DELETE_ARRIVAL                                         */
@@ -35,6 +25,7 @@ ALTER VIEW [labkey_etl].[V_DELETE_ARRIVAL] AS
 -- Changes:
 -- 3/10/2021 Removed the join on the v_demographics view - if animal is removed from the colony
 --      before the arrivals ETL runs, then the arrivals deletion will be missed
+-- 7/2/2021 added join to improved demographics source which includes animals removed from colony. tjh
 --
 -- ==========================================================================================
 
@@ -42,6 +33,7 @@ SELECT
 	ad.object_id,
 	ad.audit_date_tm
 FROM audit.audit_acq_disp AS ad
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = ad.id
 
 WHERE ad.audit_action = 'D' AND ad.object_id IS NOT NULL
 

--- a/snprc_ehr/resources/source_queries/create_v_delete_birth.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_birth.sql
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-/****** Object:  View [labkey_etl].[V_DELETE_BIRTH]    Script Date: 6/26/2015 10:22 AM ******/
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
 
 /*==============================================================*/
 /* View: V_DELETE_BIRTH                                         */
@@ -33,7 +23,7 @@ ALTER VIEW [labkey_etl].[V_DELETE_BIRTH] AS
 -- Create date: 6/26/2015
 -- Description:	Selects the ETL records for LabKey study.birth dataset which need to be deleted
 -- Changes:
---
+-- 7/2/2021 changed demographics data source. tjh
 --
 -- ==========================================================================================
 
@@ -41,7 +31,7 @@ SELECT am.object_id,
 	am.audit_date_tm
 FROM audit.audit_master AS am
 -- select primates only from the TxBiomed colony
-INNER JOIN Labkey_etl.V_DEMOGRAPHICS AS d ON d.id = am.id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = am.id
 WHERE am.audit_action = 'D' AND am.object_id IS NOT NULL
 
 GO

--- a/snprc_ehr/resources/source_queries/create_v_delete_death.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_death.sql
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-/****** Object:  View [labkey_etl].[V_DELETE_DEATH]    Script Date: 6/26/2015 10:22 AM ******/
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
 
 /*==============================================================*/
 /* View: V_DELETE_DEATH                                         */
@@ -33,7 +23,7 @@ ALTER VIEW [labkey_etl].[V_DELETE_DEATH] AS
 -- Create date: 6/26/2015
 -- Description:	Selects the ETL records for LabKey study.birth dataset which need to be deleted
 -- Changes:
---
+-- 7/2/2021 changed demographics data source. tjh
 --
 -- ==========================================================================================
 
@@ -42,7 +32,7 @@ SELECT am.object_id,
 FROM audit.audit_master AS am
 INNER JOIN dbo.master as m on m.id = am.id
 -- select primates only from the TxBiomed colony
-INNER JOIN Labkey_etl.V_DEMOGRAPHICS AS d ON d.id = am.id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = am.id
 WHERE am.audit_action = 'D' 
   OR
 	 (m.death_date is null and am.death_date IS null

--- a/snprc_ehr/resources/source_queries/create_v_delete_departure.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_departure.sql
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-/****** Object:  View [labkey_etl].[V_DELETE_DEPARTURE]    Script Date: 6/26/2015 11:20:17 AM ******/
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
 
 /*==============================================================*/
 /* View: V_DELETE_DEPARTURE                                            */
@@ -35,13 +25,13 @@ ALTER VIEW [labkey_etl].[V_DELETE_DEPARTURE] AS
 -- Changes:
 -- 3/10/2021 Removed the join on the v_demographics view - if animal is removed from the colony
 --      before the departures ETL runs, then the departure deletion will be missed
---
+-- 7/2/2021 added join to improved demographics source which includes animals removed from colony. tjh
 -- ==========================================================================================
 
 SELECT ad.object_id,
 	   ad.audit_date_tm
 FROM audit.audit_acq_disp AS ad
-
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = ad.id
 WHERE ad.audit_action = 'D' AND ad.object_id IS NOT NULL
 
 GO

--- a/snprc_ehr/resources/source_queries/create_v_delete_diet.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_diet.sql
@@ -30,6 +30,7 @@ alter VIEW [labkey_etl].[v_delete_diet] as
 -- Object: v_delete_diet
 -- Author:		Terry Hawkins
 -- Create date: 7/15/2015
+-- 7/2/2021 changed demographics data source. tjh
 --
 -- ==========================================================================================
 SELECT 
@@ -38,7 +39,7 @@ SELECT
 
 FROM audit.audit_diet AS ad
 -- select primates only from the TxBiomed colony
-INNER JOIN Labkey_etl.V_DEMOGRAPHICS AS d ON d.id = ad.id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = ad.id
 WHERE ad.audit_action = 'D' AND ad.object_id IS NOT NULL
  
 go

--- a/snprc_ehr/resources/source_queries/create_v_delete_housing.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_housing.sql
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-SET ANSI_NULLS ON;
-GO
-
-SET QUOTED_IDENTIFIER ON;
-GO
-
 /*==============================================================*/
 /* View: V_AUDIT_LOCATION                                               */
 /*==============================================================*/
@@ -29,6 +23,7 @@ ALTER VIEW labkey_etl.v_delete_housing as
 -- Create date: 6/12/2015
 -- Changes:
 -- 12/20/2017 added audit.audit_cage_position records tjh
+-- 7/2/2021 changed demographics data source. tjh
 -- ==========================================================================================
 SELECT 
 	CAST(al.object_id AS VARCHAR(36)) AS object_id,
@@ -36,7 +31,7 @@ SELECT
 
 FROM audit.audit_location AS al
 -- select primates only from the TxBiomed colony
-INNER JOIN labkey_etl.V_DEMOGRAPHICS AS d ON d.id = al.id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = al.id
 WHERE al.audit_action = 'D' AND al.object_id IS NOT NULL
 
 UNION

--- a/snprc_ehr/resources/source_queries/create_v_delete_id_history.sql
+++ b/snprc_ehr/resources/source_queries/create_v_delete_id_history.sql
@@ -13,24 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-USE [animal]
-GO
-
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
 /*==============================================================*/
 /* View: V_DELETE_ID_HISTORY                                    */
 /*==============================================================*/
-CREATE VIEW [labkey_etl].[V_DELETE_ID_HISTORY] as
+ALTER VIEW [labkey_etl].[V_DELETE_ID_HISTORY] as
 -- ====================================================================================================================
 -- Author:		Terry Hawkins
 -- Create date: 7/30/2015
 --
 -- Changes:
+-- 7/2/2021 changed demographics data source. tjh
 -- ==========================================================================================
 SELECT 
 	aih.object_id,
@@ -38,13 +30,12 @@ SELECT
 
 FROM audit.audit_id_history AS aih
 -- select primates only from the TxBiomed colony
-INNER JOIN Labkey_etl.V_DEMOGRAPHICS AS d ON d.id = aih.sfbr_id
+INNER JOIN Labkey_etl.v_demographics_for_delete AS d ON d.id = aih.sfbr_id
 WHERE aih.AUDIT_ACTION = 'D' AND aih.OBJECT_ID IS NOT NULL
 
-go
+GO
 
 GRANT SELECT on labkey_etl.V_DELETE_ID_HISTORY to z_labkey
 GRANT SELECT ON audit.audit_id_history TO z_labkey
-
 
 go

--- a/snprc_ehr/resources/source_queries/create_v_demographics_for_delete.sql
+++ b/snprc_ehr/resources/source_queries/create_v_demographics_for_delete.sql
@@ -1,0 +1,33 @@
+CREATE VIEW labkey_etl.v_demographics_for_delete
+AS  (
+    -- ==========================================================================================
+    -- Author:		Terry Hawkins
+    -- Create date: 7/2/2021
+    -- Description:	Selects the valid animal IDs for delete data sources
+    -- Changes:
+    -- ==========================================================================================
+
+    SELECT
+        m.id AS id
+    FROM
+        dbo.master m
+    WHERE
+        m.species <> 'MDA'
+    UNION
+    SELECT
+        am.id AS id
+    FROM
+        audit.audit_master am
+    WHERE
+        am.species <> 'MDA'
+        AND am.audit_action = 'D');
+
+GO
+
+GRANT
+    SELECT
+    ON labkey_etl.v_demographics_for_delete
+    TO
+    z_labkey;
+
+GO

--- a/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRSequencer.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRSequencer.java
@@ -31,6 +31,7 @@ import java.util.Map;
 public enum SNPRC_EHRSequencer
 {
     ANIMALID("org.labkey.snprc_ehr.domain.AnimalId", 100);
+    // "last value assigned" is stored in the table - not the same as CAMP which is the "next value to assign"
     // new sequences are added here
     // example:
     // ANIMALID("org.labkey.snprc_ehr.domain.AnimalId", 0),


### PR DESCRIPTION
#### Rationale
ETL improvements for deleting data for animals that are removed from the colony (a once in a blue moon event)

#### Related Pull Requests
none

#### Changes
1. Fixed column in NewAnimalData export query
2. Added new demographics data delete source for ETLs (includes deleted animals)
3. Fixed source query (removed participantSequenceNum column) for cases and animal event narratives
4. Changed demographics data source for ETL delete queries
5. Added comment to SNPRC_EHRSequencer.java