### PR TITLE
ValidDiet.js was using wrong value to generate snomed code

### DIFF
--- a/snprc_ehr/resources/queries/snprc_ehr/ExportNewAnimalData.sql
+++ b/snprc_ehr/resources/queries/snprc_ehr/ExportNewAnimalData.sql
@@ -11,14 +11,16 @@
  Adding SourceInstitution column to hold source institution for
   non-birth acquisitions.
   srr 03.31.2021
+ Removed seconds from birth and acquisition
+  srr 07.07.2021
  ********************************************************/
 
 SELECT
     n.Id,
-    n.BirthDate,
+    timestampadd(SQL_TSI_SECOND, -second(n.BirthDate), n.BirthDate) AS BirthDate,
     n.BirthCode as Bd_Status,
     n.AcquisitionType,
-    n.AcqDate AS AcquisitionDate,
+    timestampadd(SQL_TSI_SECOND, -second(n.AcqDate), n.AcqDate) AS AcquisitionDate,
     n.SourceInstitutionLocation.code as SourceInstitutionLocation,
     n.species,
     n.Gender,

--- a/snprc_ehr/resources/queries/snprc_ehr/ValidDiet.js
+++ b/snprc_ehr/resources/queries/snprc_ehr/ValidDiet.js
@@ -1,19 +1,30 @@
 //var console = require("console");
 var LABKEY = require("labkey");
+
 var snprcTriggerHelper = new org.labkey.snprc_ehr.query.SNPRC_EHRTriggerHelper(LABKEY.Security.currentUser.id, LABKEY.Security.currentContainer.id);
+
 function beforeInsert(row,errors) {
     var dCode = snprcTriggerHelper.getNextDietCode();
-    //console.log("dCode is " + dCode);
-    //console.log("row is " + row);
+    console.log("dCode is " + dCode);
+    console.log("row is " + row);
+    console.log("rowDietCodePre is " + row.DietCode);
+
     if (row.DietCode === undefined || row.DietCode == 'undefined') {
        row.DietCode = dCode;
       //  row.DietCode  = snprcTriggerHelper.getNextDietCode();
     }
+
+    console.log("rowDietCodePost is " + row.DietCode);
+    console.log("rowSnomedCodePre is " + row.SnomedCode);
     if (row.SnomedCode === undefined || row.SnomedCode == 'undefined') {
         // Used to generate a 7 character FauxMed code i.e. S-001234
-        var fauxRight = "00000" + dCode;
+
+        // changed fauzRight to use DietCode instead of dCode.
+        // dCode would only work for TAC sourced new diet
+        var fauxRight = "00000" + row.DietCode;
         row.SnomedCode = "S-" + fauxRight.slice(fauxRight.length-5,fauxRight.length);
     }
+    console.log("rowSnomedCodePost is " + row.SnomedCode);
     row.objectid = row.objectid || LABKEY.Utils.generateUUID().toUpperCase();
 
 }

--- a/snprc_ehr/resources/source_queries/create_v_valid_diet.sql
+++ b/snprc_ehr/resources/source_queries/create_v_valid_diet.sql
@@ -25,15 +25,16 @@ ALTER VIEW [labkey_etl].[v_valid_diet] AS
 --
 -- 03/11/2019  srr added tid as DietId
 -- 03/19/2019  srr refactored DietId to DietCode to better agree with naming elsewhere
+-- 07/07/2021   srr formatting changes
 -- ==========================================================================================
 
 SELECT
-  vd.diet							    AS Diet,
-  vd.arc_species_code		AS ARCSpeciesCode,
+  vd.diet							AS Diet,
+  vd.arc_species_code		        AS ARCSpeciesCode,
   vd.start_date						AS StartDate,
   vd.stop_date						AS StopDate,
   vd.snomed_code					AS SnomedCode,
-  vd.tid                 AS DietCode,
+  vd.tid                            AS DietCode,
   vd.object_id						AS objectid,
   vd.entry_date_tm					AS modified,
   dbo.f_map_username(vd.user_name)	AS modifiedby,


### PR DESCRIPTION
Diet fix for failing ETL, Removed seconds from NewAnimalDate
srr 07.07.2021

#### Rationale
Fix for failing ETLs

#### Changes
* ValidDiet.js was using wrong value to generate snomed code
* create_v_valid_diet.sql Cleaned up formatting.
* ExportNewAnimalData.sql now removes seconds from date-time values
