### PR TITLE
Re-fix testProceduresBeforeDispositionReport

### DIFF
--- a/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
+++ b/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
@@ -771,7 +771,7 @@ public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOn
 
         participantViewPage.clickReportTab("Procedures Before Disposition");
         remarkColumn = participantViewPage.getActiveReportDataRegion().getColumnDataAsText("Procedure Text");
-        assertEquals("Report should show events less than or equal to 3 days before death", Arrays.asList("necropsy +1days", "necropsy -0days", "necropsy -3days"), remarkColumn);
+        assertEquals("Report should show events less than or equal to 3 days before death", Arrays.asList("necropsy +1days", "necropsy -0days", "necropsy -3days", "necropsy -4days"), remarkColumn);
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
This was changed due to an update in trigger behavior that seemed to fit a different test result. This filter, +/- 3 days, does not include the current day (day 0), so the original test results are correct.  The trigger behavior has been corrected. This PR rolls back the change to the test. 

#### Changes
* Update expected results
