### PR TITLE
Remove study-archive-generating tasks

### DIFF
--- a/snprc_ehr/build.gradle
+++ b/snprc_ehr/build.gradle
@@ -13,27 +13,4 @@ dependencies
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:snd", depProjectConfig: "published", depExtension: "module")
-
         }
-
-task('metadataStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset metadata") {
-   archiveFileName.set('snprc_study_metadata.zip')
-   destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
-   from("resources/referenceStudy/") {
-      include "study.xml"
-      include "datasets/*"
-      exclude "datasets/*.tsv"
-   }
-}
-project.tasks.module.dependsOn(project.tasks.metadataStudyArchive)
-
-task('datasetStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset data") {
-   archiveFileName.set('snprc_study.zip')
-   destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
-   from("resources/referenceStudy/") {
-      include "study.xml"
-      include "datasets/*"
-   }
-}
-
-project.tasks.module.dependsOn(project.tasks.datasetStudyArchive)

--- a/snprc_r24/build.gradle
+++ b/snprc_r24/build.gradle
@@ -1,27 +1,5 @@
 import org.labkey.gradle.util.GroupNames
 
-task('metadataStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset metadata") {
-    archiveFileName.set('snprc_r24_metadata.zip')
-    destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
-    from("resources/referenceStudy/") {
-        include "study.xml"
-        include "datasets/*"
-        exclude "datasets/*.tsv"
-    }
-}
-project.tasks.module.dependsOn(project.tasks.metadataStudyArchive)
-
-task('datasetStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset data") {
-    archiveFileName.set( 'snprc_r24.zip')
-    destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
-    from("resources/referenceStudy/") {
-        include "study.xml"
-        include "datasets/*"
-    }
-}
-
-project.tasks.module.dependsOn(project.tasks.datasetStudyArchive)
-
 sourceSets {
     transform {
         java {


### PR DESCRIPTION
#### Rationale
These tasks are no longer needed plus support for study archives is going away