### PR TITLE
Fix snprc builds - stop pinning a specific version of poi-ooxml-schemas

### DIFF
--- a/snprc_genetics/build.gradle
+++ b/snprc_genetics/build.gradle
@@ -13,7 +13,6 @@ sourceSets {
 dependencies {
     transformImplementation "org.apache.poi:poi:${poiVersion}"
     transformImplementation "org.apache.poi:poi-ooxml:${poiVersion}"
-    transformImplementation "org.apache.poi:poi-ooxml-schemas:${poiVersion}"
     transformImplementation "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
     transformImplementation "com.google.guava:guava:${guavaVersion}"
     transformImplementation "org.apache.commons:commons-collections4:${commonsCollections4Version}"

--- a/snprc_r24/build.gradle
+++ b/snprc_r24/build.gradle
@@ -11,7 +11,6 @@ sourceSets {
 dependencies {
     transformImplementation "org.apache.poi:poi:${poiVersion}"
     transformImplementation "org.apache.poi:poi-ooxml:${poiVersion}"
-    transformImplementation "org.apache.poi:poi-ooxml-schemas:${poiVersion}"
     transformImplementation "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
     transformImplementation "com.google.guava:guava:${guavaVersion}"
     transformImplementation "org.apache.commons:commons-collections4:${commonsCollections4Version}"


### PR DESCRIPTION
#### Rationale
We've upgraded POI to 5.2.0, but dependency poi-ooxml-schemas remains at 4.1.2. These SNPRC builds were declaring a dependency on poi-ooxml-schemas 5.2.0, which doesn't exist.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3023
