### PR TITLE
Remove unused <categories> elements from datasets_manifest.xml files in sample archives

### DIFF
--- a/snprc_ehr/resources/referenceStudy/study/datasets/datasets_manifest.xml
+++ b/snprc_ehr/resources/referenceStudy/study/datasets/datasets_manifest.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-    <categories>
-        <category>Behavior</category>
-        <category>ClinPath</category>
-        <category>Colony Management</category>
-        <category>Clinical</category>
-        <category>Pathology</category>
-    </categories>
     <datasets>
         <dataset name="pregnancyConfirmation" id="5035" category="Colony Management" type="Standard">
             <tags/>


### PR DESCRIPTION
#### Rationale
Support for unused `<categories>` element has been removed

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3062