### PR TITLE
Added missing remark column to labwork pivot queries

### DIFF
--- a/snprc_ehr/resources/queries/study/CulturePivot.query.xml
+++ b/snprc_ehr/resources/queries/study/CulturePivot.query.xml
@@ -21,7 +21,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>_key</fkColumnName>
+                            <fkColumnName>objectid</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/CulturePivot.query.xml
+++ b/snprc_ehr/resources/queries/study/CulturePivot.query.xml
@@ -21,7 +21,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>message_id</fkColumnName>
+                            <fkColumnName>_key</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/CulturePivot.sql
+++ b/snprc_ehr/resources/queries/study/CulturePivot.sql
@@ -24,6 +24,7 @@ SELECT
     p.date,
     p.serviceTestId.testName as TestName,
     p.runId.serviceRequested as PanelName,
+    p.remark,
     GROUP_CONCAT(p.qualresult) as QResults
 
 FROM study.labworkResults as p
@@ -32,7 +33,7 @@ FROM study.labworkResults as p
                         and lt.ServiceId.Dataset='Culture'
 
 where p.id is not null
-  group by p.runid, p.Id, p.date,p.serviceTestId.testName, p.runId.serviceRequested
+  group by p.runid, p.Id, p.date,p.serviceTestId.testName, p.remark, p.runId.serviceRequested
     PIVOT   QResults by TestName IN
   (select  t.testName from snprc_ehr.labwork_panels t
   where t.includeInPanel = true

--- a/snprc_ehr/resources/queries/study/ParasitologyPivot.query.xml
+++ b/snprc_ehr/resources/queries/study/ParasitologyPivot.query.xml
@@ -21,7 +21,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>message_id</fkColumnName>
+                            <fkColumnName>objectid</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/ParasitologyPivot.sql
+++ b/snprc_ehr/resources/queries/study/ParasitologyPivot.sql
@@ -22,6 +22,7 @@ SELECT
   p.runid,
   p.Id,
   p.date,
+  p.remark,
   p.serviceTestId.testName as TestName,
   p.runId.serviceRequested as PanelName,
   GROUP_CONCAT(p.qualresult) as QResults
@@ -33,7 +34,7 @@ FROM study.labworkResults as p
 
 where p.id is not null
   and p.runId.serviceRequested not in ('OVA & PARASITES','OVA & PARASITES, URINE')
-group by p.runid, p.Id, p.date,p.serviceTestId.testName, p.runId.serviceRequested
+group by p.runid, p.Id, p.date,p.serviceTestId.testName, p.runId.serviceRequested, p.remark
   PIVOT QResults by TestName IN
   (select TestName from snprc_ehr.labwork_panels t
   where t.includeInPanel = true

--- a/snprc_ehr/resources/queries/study/ParasitologyPivotOP.query.xml
+++ b/snprc_ehr/resources/queries/study/ParasitologyPivotOP.query.xml
@@ -27,7 +27,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>message_id</fkColumnName>
+                            <fkColumnName>objectid</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/ParasitologyPivotOP.sql
+++ b/snprc_ehr/resources/queries/study/ParasitologyPivotOP.sql
@@ -25,6 +25,7 @@ SELECT
   p.date,
   p.serviceTestId.testName as TestName,
   p.runId.serviceRequested as PanelName,
+  p.remark,
   GROUP_CONCAT(p.qualresult) as QResults
 
 FROM study.labworkResults as p
@@ -34,7 +35,7 @@ FROM study.labworkResults as p
 
 where p.id is not null
       and p.runId.serviceRequested  in ('OVA & PARASITES' ,'OVA & PARASITES, URINE')
-group by p.runid, p.Id, p.date, p.serviceTestId.testName, p.runId.serviceRequested
+group by p.runid, p.Id, p.date,p.remark, p.serviceTestId.testName, p.runId.serviceRequested
   PIVOT QResults by TestName IN
   (select TestName from snprc_ehr.labwork_panels t
   where t.includeInPanel = true

--- a/snprc_ehr/resources/queries/study/chemPivot.sql
+++ b/snprc_ehr/resources/queries/study/chemPivot.sql
@@ -19,11 +19,12 @@ b.date,
 b.runId,
 b.panelName,
 b.TestName,
+b.remark,
 MAX(b.result) as results
 
 FROM chemPivotInner b
 
-GROUP BY b.runid,b.id, b.date, b.TestName, b.panelName
+GROUP BY b.runid,b.id, b.date, b.TestName, b.panelName, b.remark
 
 PIVOT results BY TestName IN
 (select TestName from snprc_ehr.labwork_panels t

--- a/snprc_ehr/resources/queries/study/chemPivotInner.sql
+++ b/snprc_ehr/resources/queries/study/chemPivotInner.sql
@@ -20,6 +20,7 @@ SELECT
   b.serviceTestId.testName AS TestName,
 
   coalesce(b.runId, b.objectid) as runId,
+  b.remark,
   b.resultoorindicator,
   CASE
   WHEN b.result IS NULL THEN  b.qualresult

--- a/snprc_ehr/resources/queries/study/hematologyPivot.query.xml
+++ b/snprc_ehr/resources/queries/study/hematologyPivot.query.xml
@@ -27,7 +27,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>message_id</fkColumnName>
+                            <fkColumnName>objectid</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/hematologyPivot.sql
+++ b/snprc_ehr/resources/queries/study/hematologyPivot.sql
@@ -19,11 +19,12 @@ b.date,
 b.runid,
 b.panelName,
 b.TestName,
+b.remark,
 MAX(b.result) as results
 
 FROM hematologyPivotInner b
 
-GROUP BY b.runid, b.panelName, b.id, b.date, b.TestName
+GROUP BY b.runid, b.panelName, b.id, b.date, b.TestName, b.remark
 
 PIVOT results BY TestName IN
 (select TestName from snprc_ehr.labwork_panels t

--- a/snprc_ehr/resources/queries/study/hematologyPivotInner.sql
+++ b/snprc_ehr/resources/queries/study/hematologyPivotInner.sql
@@ -19,6 +19,7 @@ SELECT
     b.runId.serviceRequested as panelName,
     b.serviceTestId.testName AS TestName,
     coalesce(b.runId, b.objectid) as runId,
+    b.remark,
     b.resultoorindicator,
     CASE
     WHEN b.result IS NULL THEN  b.qualresult

--- a/snprc_ehr/resources/queries/study/miscPivot.query.xml
+++ b/snprc_ehr/resources/queries/study/miscPivot.query.xml
@@ -27,7 +27,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>message_id</fkColumnName>
+                            <fkColumnName>objectid</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/miscPivot.sql
+++ b/snprc_ehr/resources/queries/study/miscPivot.sql
@@ -19,12 +19,12 @@ SELECT
     b.runId,
     b.panelName,
     b.TestName,
+    b.remark,
     MAX(b.result) as results,
-    (select group_concat(a.remark) from study.labworkResults as a where a.runId = b.runId) as remark
 
 FROM miscPivotInner b
 
-GROUP BY b.runid,b.id, b.date, b.TestName, b.panelName
+GROUP BY b.runid,b.id, b.date, b.TestName, b.panelName, b.remark
 
 PIVOT results BY TestName IN
 (select TestName from snprc_ehr.labwork_panels t

--- a/snprc_ehr/resources/queries/study/miscPivotInner.sql
+++ b/snprc_ehr/resources/queries/study/miscPivotInner.sql
@@ -18,7 +18,7 @@ SELECT
   b.date,
   b.runId.serviceRequested as panelName,
   b.serviceTestId.testName AS TestName,
-
+  b.remark,
   coalesce(b.runId, b.objectid) as runId,
   b.resultoorindicator,
   CASE

--- a/snprc_ehr/resources/queries/study/surveillancePivot.query.xml
+++ b/snprc_ehr/resources/queries/study/surveillancePivot.query.xml
@@ -27,7 +27,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>message_id</fkColumnName>
+                            <fkColumnName>objectid</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/surveillancePivot.sql
+++ b/snprc_ehr/resources/queries/study/surveillancePivot.sql
@@ -19,11 +19,12 @@ b.date,
 b.runid,
 b.panelName,
 b.TestName,
+b.remark,
 MAX(b.result) as results
 
 FROM surveillancePivotInner b
 
-GROUP BY b.runid, b.panelName, b.id, b.date, b.TestName
+GROUP BY b.runid, b.panelName, b.id, b.date, b.TestName, b.remark
 
 PIVOT results BY TestName IN
 (select TestName from snprc_ehr.labwork_panels t

--- a/snprc_ehr/resources/queries/study/surveillancePivotInner.sql
+++ b/snprc_ehr/resources/queries/study/surveillancePivotInner.sql
@@ -24,6 +24,7 @@ SELECT
     b.serviceTestId.testName AS TestName,
     coalesce(b.runId, b.objectid) as runId,
     b.resultoorindicator,
+    b.remark,
     CASE
     WHEN b.result IS NULL THEN  b.qualresult
       ELSE CAST(CAST(b.result AS float) AS VARCHAR)
@@ -40,6 +41,7 @@ SELECT
   b.serviceTestId.testName AS TestName,
   coalesce(b.runId, b.objectid) as runId,
   b.resultoorindicator,
+  b.remark,
   CASE
   WHEN b.result IS NULL THEN b.qualresult
     ELSE CAST(CAST(b.result AS float) AS VARCHAR)
@@ -56,6 +58,7 @@ SELECT
     b.serviceTestId.testName AS TestName,
     coalesce(b.runId, cast(b.Sequencenum as varchar)) as runId,
     b.resultoorindicator,
+    b.remark,
     CASE
         WHEN b.result IS NULL THEN b.qualresult
         ELSE CAST(CAST(b.result AS float) AS VARCHAR)

--- a/snprc_ehr/resources/queries/study/urinalysisPivot.query.xml
+++ b/snprc_ehr/resources/queries/study/urinalysisPivot.query.xml
@@ -27,7 +27,7 @@
                         <fk>
                             <fkDbSchema>study</fkDbSchema>
                             <fkTable>ClinpathRuns</fkTable>
-                            <fkColumnName>message_id</fkColumnName>
+                            <fkColumnName>objectid</fkColumnName>
                         </fk>
                     </column>
                 </columns>

--- a/snprc_ehr/resources/queries/study/urinalysisPivot.sql
+++ b/snprc_ehr/resources/queries/study/urinalysisPivot.sql
@@ -19,11 +19,12 @@ SELECT
   b.runId,
   b.panelName,
   b.TestName,
+  b.remark,
   MAX(b.result) as results
 
 FROM urinalysisPivotInner b
 
-GROUP BY b.runid,b.id, b.date, b.TestName, b.panelName
+GROUP BY b.runid,b.id, b.date, b.TestName, b.panelName, b.remark
 
 PIVOT results BY TestName IN
 (select TestName from snprc_ehr.labwork_panels t

--- a/snprc_ehr/resources/queries/study/urinalysisPivotInner.sql
+++ b/snprc_ehr/resources/queries/study/urinalysisPivotInner.sql
@@ -21,6 +21,7 @@ SELECT
 
   coalesce(b.runId, b.objectid) as runId,
   b.resultoorindicator,
+  b.remark,
   CASE
   WHEN b.result IS NULL THEN  b.qualresult
   ELSE CAST(CAST(b.result AS float) AS VARCHAR)


### PR DESCRIPTION
#### Rationale
Result data is often recorded in the remark column.

#### Related Pull Requests

#### Changes
Added remark column to the following pivot queries:
CulturePivot
ChemPivot
HematologyPivot
MiscPivot
ParasitologyPivot
ParasitologyPivotOP
SurveillancePivot
UrinalysisPivot

- Fixed FK metada 
