### PR TITLE
 NewAnimalWizard should allow senior-aged marmosets to be potential sires

### DIFF
--- a/snprc_ehr/resources/queries/study/PotentialSires.sql
+++ b/snprc_ehr/resources/queries/study/PotentialSires.sql
@@ -21,7 +21,9 @@ FROM study.demographics AS d
            gender,
            label
     FROM ehr_lookups.ageclass AS ac
-) as x ON d.species.arc_species_code = x.species and x.label = 'Adult' AND (x.gender = 'M' OR x.gender is NULL)
+) as x ON d.species.arc_species_code = x.species
+    AND (x.label = 'Adult' OR (d.species.arc_species_code = 'CJ' AND x.label = 'Senior' ))
+    AND (x.gender = 'M' OR x.gender is NULL)
 
 -- hard code until the gestation data is available in LK - use 185 if we don't have a value
          INNER JOIN (


### PR DESCRIPTION
#### Rationale
Incident #9058 TAC new animal wizard choice of male for sire error 

#### Related Pull Requests
none

#### Changes
Tweaked potentialSires.sql to allow senior-aged marmosets to be sires
