### PR TITLE
Update artifactory URL for 22.3

### DIFF
--- a/snprc_ehr/.npmrc
+++ b/snprc_ehr/.npmrc
@@ -1,2 +1,2 @@
 # Set registry for @labkey scopes
-@labkey:registry=https://artifactory.labkey.com/artifactory/api/npm/libs-client/
+@labkey:registry=https://labkey.jfrog.io/artifactory/api/npm/libs-client/

--- a/snprc_ehr/package-lock.json
+++ b/snprc_ehr/package-lock.json
@@ -2977,13 +2977,13 @@
     },
     "node_modules/@labkey/api": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
       "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA=",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/components": {
       "version": "2.154.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.154.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.154.1.tgz",
       "integrity": "sha1-josiWJRjK926phfMSXzQLylnKm0=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -25070,12 +25070,12 @@
     },
     "@labkey/api": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
       "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA="
     },
     "@labkey/components": {
       "version": "2.154.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.154.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.154.1.tgz",
       "integrity": "sha1-josiWJRjK926phfMSXzQLylnKm0=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",


### PR DESCRIPTION
#### Rationale
Artifactory migration

#### Related Pull Requests
* [Server](https://github.com/LabKey/server/pull/280)

#### Changes
* Update artifactory url in package.json and package-lock.json