### PR TITLE
Update artifactory URL for 21.11

### DIFF
--- a/snprc_ehr/.npmrc
+++ b/snprc_ehr/.npmrc
@@ -1,2 +1,2 @@
 # Set registry for @labkey scopes
-@labkey:registry=https://artifactory.labkey.com/artifactory/api/npm/libs-client/
+@labkey:registry=https://labkey.jfrog.io/artifactory/api/npm/libs-client/

--- a/snprc_ehr/package-lock.json
+++ b/snprc_ehr/package-lock.json
@@ -2311,12 +2311,12 @@
     },
     "@labkey/api": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.0.tgz",
       "integrity": "sha1-tw++dJ18OzCud/XY6eEqLN5c7b4="
     },
     "@labkey/components": {
       "version": "0.97.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.97.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.97.0.tgz",
       "integrity": "sha1-EeGjxLxb4h+c9AWbmJzdj/vCRw0=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
@@ -2358,7 +2358,7 @@
       "dependencies": {
         "@labkey/api": {
           "version": "1.1.1",
-          "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.1.tgz",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.1.1.tgz",
           "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
         },
         "react-datepicker": {


### PR DESCRIPTION
#### Rationale
Artifactory migration

#### Related Pull Requests
* [Server](https://github.com/LabKey/server/pull/281)

#### Changes
* Update artifactory url in package.json and package-lock.json