### PR TITLE
Migrate to new JSONObject/JSONArray library

### DIFF
--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
@@ -308,9 +308,6 @@ public class SNPRC_schedulerController extends SpringActionController
                     errors.reject(ERROR_MSG, "timelineId is present but not a valid integer.");
                 }
             }
-
-            return;
-
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
We want to use the new `org.json.JSON*` library