### PR TITLE
Previous change to queries broke automated testing

### DIFF
--- a/snprc_ehr/resources/queries/study/clinpathRunsAll.sql
+++ b/snprc_ehr/resources/queries/study/clinpathRunsAll.sql
@@ -13,6 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+SELECT
+    cpr.Id,
+    cpr.date,
+    cpr.enddate,
+    COALESCE(cpr.serviceId.Dataset.ServiceType, cpr.type) as type,
+    cpr.tissue,
+    cpr.project,
+    cpr.instructions,
+    cpr.servicerequested,
+    cpr.units,
+    cpr.serviceId,
+    cpr.collectedBy,
+    cpr.sampleId,
+    cpr.collectionMethod,
+    cpr.method,
+    cpr.sampleQuantity,
+    cpr.quantityUnits,
+    cpr.chargetype,
+    cpr.verifiedDate,
+    cpr.datefinalized,
+    lr.remark as remark,
+    cpr.history,
+    cpr.objectid,
+    cpr.lsid,
+    cpr.QCState
+FROM study.clinpathRuns cpr
+         LEFT JOIN study.labworkResults lr on lr.runId = cpr.objectId and lr.remark is not null
+UNION
+
 select
     obr.ANIMAL_ID as Id,
     obr.OBSERVATION_DATE_TM AS date,

--- a/snprc_ehr/resources/queries/study/labworkResultsAll.sql
+++ b/snprc_ehr/resources/queries/study/labworkResultsAll.sql
@@ -20,7 +20,30 @@
    7/13/2022 Refactored to use HL7 tables from Orchard
 
  */
+SELECT
+    lr.Id,
+    lr.date,
+    lr.project,
+    lr.serviceId,
+    lp.objectID AS serviceTestId,
+    lr.testid,
+    lr.resultOORIndicator,
+    lr.value_type,
+    lr.result,
+    lr.units,
+    lr.qualresult,
+    lr.refRange,
+    lr.abnormal_flags,
+    lr.runid,
+    lr.enddate,
+    lr.method,
+    lr.remark,
+    lr.objectId,
+    lr.QCState
+FROM study.labworkResults lr
+         LEFT OUTER JOIN snprc_ehr.labwork_Panels AS lp ON lr.testId = lp.TestId AND lr.serviceId = lp.ServiceId
 
+UNION
 
 SELECT
     obr.ANIMAL_ID AS Id,


### PR DESCRIPTION
- study.labworkResults needed in labworkResultsAll query for the test suite
- study.clinPathRuns needed in clinpathRunsAll query for the test suite
