### PR TITLE
Use non-deprecated JSON-related method and interface names

### DIFF
--- a/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalGroupsController.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalGroupsController.java
@@ -430,19 +430,19 @@ public class AnimalGroupsController extends SpringActionController
         @Override
         public ApiResponse execute(SimpleApiJsonForm simpleApiJsonForm, BindException errors)
         {
-            Map<String, Object> props = new HashMap<String, Object>();
-            JSONObject json = simpleApiJsonForm.getNewJsonObject();
+            Map<String, Object> props = new HashMap<>();
+            JSONObject json = simpleApiJsonForm.getJsonObject();
 
             JSONArray rows;
 
             try
             {
-                rows = (JSONArray) json.get("rows");
+                rows = json.getJSONArray("rows");
             }
             catch (Exception exp)
             {
                 rows = new JSONArray();
-                rows.put(0, (JSONObject) json.get("rows"));
+                rows.put(0, json.get("rows"));
             }
             UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), "snprc_ehr");
             TableInfo table = schema.getTable("animal_groups", null, true, false);
@@ -574,16 +574,16 @@ public class AnimalGroupsController extends SpringActionController
         {
 
             Map<String, Object> props = new HashMap<>();
-            JSONObject json = simpleApiJsonForm.getNewJsonObject();
+            JSONObject json = simpleApiJsonForm.getJsonObject();
             JSONArray rows;
             try
             {
-                rows = (JSONArray) json.get("rows");
+                rows = json.getJSONArray("rows");
             }
             catch (Exception exp)
             {
                 rows = new JSONArray();
-                rows.put(0, (JSONObject) json.get("rows"));
+                rows.put(0, json.get("rows"));
             }
 
             UserSchema us = new SNPRC_EHRUserSchema(getUser(), getContainer());

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
@@ -289,7 +289,7 @@ public class SNPRC_schedulerController extends SpringActionController
         @Override
         public void validateForm(SimpleApiJsonForm form, Errors errors)
         {
-            JSONObject json = form.getNewJsonObject();
+            JSONObject json = form.getJsonObject();
             if (json == null)
             {
                 errors.reject(ERROR_MSG, "Missing json parameter.");
@@ -314,7 +314,7 @@ public class SNPRC_schedulerController extends SpringActionController
         public ApiResponse execute(SimpleApiJsonForm form, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
-            JSONObject json = form.getNewJsonObject();
+            JSONObject json = form.getJsonObject();
             JSONObject responseJson = null;
 
             BatchValidationException err = new BatchValidationException();


### PR DESCRIPTION
#### Rationale
`getNewJsonObject()` and `NewCustomApiForm` have replacements with better names