### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/snprc_genetics/build.gradle
+++ b/snprc_genetics/build.gradle
@@ -1,6 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
-import org.gradle.api.tasks.bundling.Jar
 
 sourceSets {
     transform {
@@ -29,17 +28,15 @@ configurations {
     }
 }
 
-project.task("transformJar",
-    group: GroupNames.BUILD,
-    type: Jar,
-    description: "Create the genetics transform jar file",
+project.tasks.register("transformJar", Jar)
     {Jar jar ->
+        jar.group = GroupNames.BUILD
+        jar.description = "Create the genetics transform jar file"
         jar.from project.sourceSets.transform.output
         jar.from { configurations.transformJars.collect { it.isDirectory() ? it : zipTree(it) }}
         jar.duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
         jar.archiveBaseName.set("GeneticsTransform")
         jar.destinationDirectory = new File(project.buildDir, "artifacts/snprc")
     }
-)
 
-project.tasks.module.dependsOn(project.tasks.transformJar)
+project.tasks.named('module').configure { dependsOn(project.tasks.transformJar) }

--- a/snprc_r24/build.gradle
+++ b/snprc_r24/build.gradle
@@ -23,11 +23,11 @@ configurations {
     }
 }
 
-project.task("transformJar",
-        group: GroupNames.BUILD,
-        type: Jar,
-        description: "Create the transform jar file",
+project.tasks.register("transformJar", Jar)
         {Jar jar ->
+            jar.group = GroupNames.BUILD
+            jar.description = "Create the transform jar file"
+
             jar.from project.sourceSets.transform.output
             jar.from { configurations.transformJars.collect { it.isDirectory() ? it : zipTree(it) }}
             jar.archiveBaseName.set("MicrobiomeTransform")
@@ -38,11 +38,9 @@ project.task("transformJar",
                 attributes "Main-Class": "MicrobiomeTransform"
             }
         }
-)
 
 project.artifacts {
     archives project.tasks.transformJar
 }
 
-project.tasks.module.dependsOn(project.tasks.transformJar)
-
+project.tasks.named('module').configure { dependsOn(project.tasks.transformJar) }


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration