### PR TITLE
Refactored BCS query to prevent filtering errors

### DIFF
--- a/snprc_ehr/resources/queries/study/BodyConditionScores.sql
+++ b/snprc_ehr/resources/queries/study/BodyConditionScores.sql
@@ -1,17 +1,14 @@
-
 SELECT
     p.id as Id,
     p.date as BcsDate,
     p.procNarrative as BCS,
-    case when substring(p.procNarrative, 7, 1) = ' ' then  cast(substring (p.procNarrative, 6,1) as float)
-         else cast( substring (p.procNarrative, 6,3) as float )
-         end as BCSValue,
+    CAST (SUBSTRING(p.procNarrative, 6, CHARINDEX(' ', p.procNarrative,6) - 6) AS double) AS BCSValue,
     p.Created,
     p.CreatedBy,
     p.Modified,
     p.ModifiedBy
-
 FROM study.procedure AS p
-WHERE p.qcstate.publicdata = true
-  AND p.pkgId.categories like '%BCS%'
-  AND p.procNarrative <> 'BCS: error'
+         INNER JOIN snprc_ehr.package_category_junction as pcj ON p.pkgId = pcj.packageId
+         INNER JOIN snprc_ehr.package_category as pc ON pc.id = pcj.categoryId and pc.description like '%BCS%'
+         INNER JOIN core.QCState as q ON p.qcstate = q.RowId and  q.Label = 'Completed'
+WHERE p.procNarrative <> 'BCS: error'


### PR DESCRIPTION
#### Rationale
see ticket # 47980 - - Adding a filter on species codes in the BSC query produces a data conversion error when equals is used but succeeds when contains is used - refactoring the query changes the behavior

#### Related Pull Requests
None

#### Changes
* Refactored BCS query to use explicit joins instead of LK FKs, and changed case statement to a substring process.
