### PR TITLE
Replaced unsupported setImmediate() call with setTimeout()

### DIFF
--- a/snprc_ehr/src/client/ChipReader/components/ChipDataPanel.jsx
+++ b/snprc_ehr/src/client/ChipReader/components/ChipDataPanel.jsx
@@ -23,7 +23,7 @@ onConnectClick = () => {
             })
         }
     }
-flushPromises = () => { return new Promise(resolve => setImmediate(resolve)) }
+flushPromises = () => { return new Promise(resolve => setTimeout(resolve)) }
 onStartClick = async () => {
         if (this.state.connection && !this.state.isReading) {
             this.setState(prevState => (


### PR DESCRIPTION
#### Rationale
Chip reader Bug fix

#### Related Pull Requests
none
