### PR TITLE
Replace deprecated buildDir with layout.buildDirectory

### DIFF
--- a/snprc_genetics/build.gradle
+++ b/snprc_genetics/build.gradle
@@ -36,7 +36,7 @@ project.tasks.register("transformJar", Jar)
         jar.from { configurations.transformJars.collect { it.isDirectory() ? it : zipTree(it) }}
         jar.duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
         jar.archiveBaseName.set("GeneticsTransform")
-        jar.destinationDirectory = new File(project.buildDir, "artifacts/snprc")
+        jar.destinationDirectory.set(project.layout.buildDirectory.file("artifacts/snprc").get().asFile)
     }
 
 project.tasks.named('module').configure { dependsOn(project.tasks.transformJar) }

--- a/snprc_r24/build.gradle
+++ b/snprc_r24/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.util.BuildUtils
 
 sourceSets {
     transform {
@@ -33,7 +34,7 @@ project.tasks.register("transformJar", Jar)
             jar.archiveBaseName.set("MicrobiomeTransform")
             jar.archiveClassifier.set("transform")
             jar.duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
-            jar.destinationDirectory = new File(project.buildDir, "artifacts/snprc")
+            jar.destinationDirectory.set(BuildUtils.getBuildDirFile(project, "artifacts/snprc"))
             jar.manifest {
                 attributes "Main-Class": "MicrobiomeTransform"
             }


### PR DESCRIPTION
#### Rationale
In Gradle 8.3, the use of `project.buildDir` was [deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir) in favor of `project.layout.buildDirectory`.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/185

#### Changes
* Replace deprecated buildDir with layout.buildDirectory
* Use `destinationDirectory.set` to avoid warnings
