### PR TITLE
Export HTML narrative as text

### DIFF
--- a/snprc_ehr/resources/queries/snd/ProcedureEventListing.query.xml
+++ b/snprc_ehr/resources/queries/snd/ProcedureEventListing.query.xml
@@ -18,6 +18,9 @@
                     </column>
                     <column columnName="HTMLNarrative">
                         <columnTitle>Narrative</columnTitle>
+                        <displayColumnFactory>
+                            <className>org.labkey.snprc_ehr.table.EventNarrativeDisplayColumnFactory</className>
+                        </displayColumnFactory>
                     </column>
                     <column columnName="AdmitChargeId">
                         <columnTitle>Admit / Charge ID</columnTitle>

--- a/snprc_ehr/src/org/labkey/snprc_ehr/table/EventNarrativeDisplayColumnFactory.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/table/EventNarrativeDisplayColumnFactory.java
@@ -1,0 +1,31 @@
+package org.labkey.snprc_ehr.table;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.snd.PlainTextNarrativeDisplayColumn;
+
+public class EventNarrativeDisplayColumnFactory implements DisplayColumnFactory
+{
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new EventNarrativeDisplayColumnFactory.EventNarrativeDisplayColumn(colInfo);
+    }
+
+    public class EventNarrativeDisplayColumn extends DataColumn
+    {
+        public EventNarrativeDisplayColumn(ColumnInfo col)
+        {
+            super(col, false);
+        }
+
+        @Override
+        public Object getExportCompatibleValue(RenderContext ctx)
+        {
+            return PlainTextNarrativeDisplayColumn.removeHtmlTagsFromNarrative((String)ctx.get(getBoundColumn().getName()));
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
For the Procedure Events React page being developed, the grid displays the HTML version of the narrative, but the export to Excel or TSV needs to be the non-HTML text version of the narrative. This PR copies in the ProcedureEventListing query used in the React page and adds the Display Column Factory to convert the HTML narrative to text.

#### Related Pull Requests
https://github.com/LabKey/snd/pull/159

#### Changes
* Copy ProcedureEventListing query and metadata
* Add DisplayColumnFactory to convert the HTML narrative to text