### PR TITLE
Snprc_scheduler - Refactor QC States

### DIFF
--- a/snprc_scheduler/resources/schemas/dbscripts/sqlserver/snprc_scheduler-18.30-23.00.sql
+++ b/snprc_scheduler/resources/schemas/dbscripts/sqlserver/snprc_scheduler-18.30-23.00.sql
@@ -1,0 +1,3 @@
+ALTER TABLE snprc_scheduler.StudyDayNotes
+    DROP COLUMN QcState
+GO

--- a/snprc_scheduler/resources/schemas/snprc_scheduler.xml
+++ b/snprc_scheduler/resources/schemas/snprc_scheduler.xml
@@ -22,7 +22,14 @@
             <column columnName="LeadTech"/>
             <column columnName="Notes"/>
             <column columnName="SchedulerNotes"/>
-            <column columnName="QcState"/>
+            <column columnName="QcState">
+                <fk>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>DataStates</fkTable>
+                    <fkColumnName>RowId</fkColumnName>
+                    <fkDisplayColumnName>Label</fkDisplayColumnName>
+                </fk>
+            </column>
             <column columnName="Created"/>
             <column columnName="CreatedBy"/>
             <column columnName="Modified"/>
@@ -124,7 +131,6 @@
             <column columnName="StudyDayNote">
                 <nullable>false</nullable>
             </column>
-            <column columnName="QcState"/>
             <column columnName="Created"/>
             <column columnName="CreatedBy"/>
             <column columnName="Modified"/>

--- a/snprc_scheduler/src/client/components/TimelineDetails.jsx
+++ b/snprc_scheduler/src/client/components/TimelineDetails.jsx
@@ -24,7 +24,7 @@ class TimelineDetails extends React.Component {
 
     handleDraftCheck = (e) => {
         this.props.onUpdateSelectedTimeline({
-            [e.target.id]: e.target.checked === true ? 4 : 1,
+            [e.target.id]: e.target.checked === true ? "In Progress" : "Completed",
             IsDirty: true
         }, true)
     };
@@ -133,8 +133,8 @@ class TimelineDetails extends React.Component {
                                 </div>
                                 <div className='col-sm-6 zero-side-padding'>
                                     <div className='col-sm-5  zero-side-padding'><ControlLabel ref='timeline-draft-state'>Draft</ControlLabel></div>
-                                    <div className='col-sm-7 zero-side-padding'><FormControl type='checkbox' id='QcState' style={{width: '20px', height: '20px'}}
-                                                                           checked={timeline.QcState ? (timeline.QcState === 4) : false}
+                                    <div className='col-sm-7 zero-side-padding'><FormControl type='checkbox' id='QcStateLabel' style={{width: '20px', height: '20px'}}
+                                                                           checked={timeline.QcStateLabel ? (timeline.QcStateLabel === "In Progress") : "Completed"}
                                                                            onChange={this.handleDraftCheck}
                                                                            disabled={!timeline.RowId || timeline.IsInUse}
                                     /></div>

--- a/snprc_scheduler/src/client/components/TimelineList.jsx
+++ b/snprc_scheduler/src/client/components/TimelineList.jsx
@@ -243,7 +243,7 @@ class TimelineList extends React.Component {
                     }
                 })
             }
-            else if (selectedTimeline.QcState !== 4) {
+            else if (selectedTimeline.QcStateLabel !== "In Progress") {
                 showAlert({
                     title: 'Delete Error',
                     msg: 'Cannot delete ' + selectedTimeline.Description + ', ' + selectedTimeline.RevisionNum + ', it is not in draft state. ' +
@@ -477,7 +477,7 @@ class TimelineList extends React.Component {
 
                                     // Add keys for any rows not selected
                                     for (const row of revTable.state.data) {
-                                        if (selections.length < 1 || selections[0] !== row.RevisionNum || me.props.selectedTimeline.QcState !== 4) {
+                                        if (selections.length < 1 || selections[0] !== row.RevisionNum || me.props.selectedTimeline.QcStateLabel !== "In Progress") {
                                             nonEdit.push(row.RevisionNum)
                                         }
                                     }

--- a/snprc_scheduler/src/client/reducers/timelineReducer.js
+++ b/snprc_scheduler/src/client/reducers/timelineReducer.js
@@ -36,7 +36,7 @@ const cloneTimeline = (source, revision) => {
         RowId: revision ? source.RowId : 0,
         RevisionNum: revision,
         Description: source.Description + (revision ? '': ' Clone'),
-        QcState: 4,
+        QcStateLabel: "In Progress",
         IsDirty: true,
         ObjectId: undefined,
         CreatedByName: undefined,
@@ -101,7 +101,7 @@ export default (state = { }, action) => {
             // Add rowid, timelineitems, timelineprojectitems and timelineanimalitems for UI
             for (const tl of nextState.timelines) {
                 tl.RowId = tl.TimelineId;
-                tl.savedDraft = (tl.QcState === 4);
+                tl.savedDraft = (tl.QcStateLabel === "In Progress");
 
 
                 if (!tl.TimelineItems) {
@@ -139,7 +139,7 @@ export default (state = { }, action) => {
                 Description: "New Timeline",
                 IsDeleted: false,
                 IsDirty: true,
-                QcState: 4,
+                QcStateLabel: "In Progress",
                 TimelineAnimalItems: [],
                 StudyDayNotes: [],
                 TimelineItems: [{RowIdx: 1, StudyDay: 0, ScheduleDate: null, IsDirty: true, IsDeleted: false}]
@@ -218,7 +218,7 @@ export default (state = { }, action) => {
             // Set rowid for UI display
             action.payload.RowId = action.payload.TimelineId;
             action.payload.IsDirty = false;
-            action.payload.savedDraft = (action.payload.QcState === 4);
+            action.payload.savedDraft = (action.payload.QcStateLabel === "In Progress");
 
             // Update list of timelines
             let timelines = nextState.timelines.map((timeline) => {

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
@@ -457,7 +457,7 @@ public class SNPRC_schedulerManager
                 timeline.setRevisionNum(getNextRevisionNum(timeline.getTimelineId()));
                 timeline.setObjectId(new GUID().toString());
                 // add default QcState
-                if (timeline.getQcState() == null) timeline.setQcState(QCStateEnum.IN_PROGRESS.getValue());
+                if (timeline.getQcState() == null) timeline.setQcState(QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS));
 
                 timelineRows.add(timeline.toMap(c, u));
 

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
@@ -457,7 +457,7 @@ public class SNPRC_schedulerManager
                 timeline.setRevisionNum(getNextRevisionNum(timeline.getTimelineId()));
                 timeline.setObjectId(new GUID().toString());
                 // add default QcState
-                if (timeline.getQcState() == null) timeline.setQcState(QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS));
+                if (timeline.getQcState() == null) timeline.setQcState(QCStateEnum.getQCStateEnumId(c,u, QCStateEnum.IN_PROGRESS));
 
                 timelineRows.add(timeline.toMap(c, u));
 

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
@@ -44,7 +44,7 @@ public class SNPRC_schedulerModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 18.30;
+        return 23.00;
     }
 
     @Override

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/Timeline.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/Timeline.java
@@ -121,7 +121,7 @@ public class Timeline //extends Entity
             this.setModifiedByName(json.optString(TIMELINE_MODIFIED_BY_NAME, null));
             this.setDescription(json.optString(TIMELINE_DESCRIPTION, null));
             // update QCState from the QCStateLabel field
-            this.setQcState(json.isNull(TIMELINE_QCSTATE_LABEL) ? null : QCStateEnum.getValueByName (c, u, QCStateEnum.getByName(json.optString(TIMELINE_QCSTATE_LABEL))));
+            this.setQcState(json.isNull(TIMELINE_QCSTATE_LABEL) ? null : QCStateEnum.getQCStateEnumId(c, u, QCStateEnum.getQCStateEnumByName(json.optString(TIMELINE_QCSTATE_LABEL))));
             this.setProjectObjectId(json.optString(TIMELINE_PROJECT_OBJECT_ID, null));
             this.setProjectId(json.isNull(TIMELINE_PROJECT_ID) ? null : json.getInt(TIMELINE_PROJECT_ID));
             this.setProjectRevisionNum(json.isNull(TIMELINE_PROJECT_REVISION_NUM) ? null : json.getInt(TIMELINE_PROJECT_REVISION_NUM));
@@ -543,7 +543,7 @@ public class Timeline //extends Entity
         values.put(TIMELINE_MODIFIED_BY, getModifiedBy());
         values.put(TIMELINE_CREATED_BY_NAME, getCreatedByName());
         values.put(TIMELINE_MODIFIED_BY_NAME, getModifiedByName());
-        values.put(TIMELINE_QCSTATE_LABEL, QCStateEnum.getQCState(c, u, getQcState()).getName());
+        values.put(TIMELINE_QCSTATE_LABEL, QCStateEnum.getQCStateEnumById(c, u, getQcState()).getName());
         values.put(TIMELINE_QCSTATE, getQcState());
         values.put(TIMELINE_PROJECT_OBJECT_ID, getProjectObjectId());
         values.put(TIMELINE_IS_DELETED, getDeleted());
@@ -624,7 +624,7 @@ public class Timeline //extends Entity
         json.put(TIMELINE_MODIFIED_BY, getModifiedBy());
         json.put(TIMELINE_CREATED_BY_NAME, getCreatedByName());
         json.put(TIMELINE_MODIFIED_BY_NAME, getModifiedByName());
-        json.put(TIMELINE_QCSTATE_LABEL, QCStateEnum.getQCState(c, u, getQcState()).getName());        //getQcState());
+        json.put(TIMELINE_QCSTATE_LABEL, QCStateEnum.getQCStateEnumById(c, u, getQcState()).getName());        //getQcState());
         json.put(TIMELINE_QCSTATE, getQcState());
         json.put(TIMELINE_PROJECT_OBJECT_ID, getProjectObjectId());
         json.put(TIMELINE_IS_DELETED, getDeleted());

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/Timeline.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/Timeline.java
@@ -9,6 +9,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.util.DateUtil;
 import org.labkey.snprc_scheduler.SNPRC_schedulerManager;
+import org.labkey.snprc_scheduler.security.QCStateEnum;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -76,6 +77,7 @@ public class Timeline //extends Entity
     public static final String TIMELINE_CREATED_BY_NAME = "CreatedByName";
     public static final String TIMELINE_MODIFIED_BY_NAME = "ModifiedByName";
     public static final String TIMELINE_QCSTATE = "QcState";
+    public static final String TIMELINE_QCSTATE_LABEL = "QcStateLabel";
     public static final String TIMELINE_TIMELINE_ITEMS = "TimelineItems";
     public static final String TIMELINE_TIMELINE_PROJECT_ITEMS = "TimelineProjectItems";
     public static final String TIMELINE_PROJECT_OBJECT_ID = "ProjectObjectId";
@@ -118,7 +120,8 @@ public class Timeline //extends Entity
             this.setCreatedByName(json.optString(TIMELINE_CREATED_BY_NAME, null));
             this.setModifiedByName(json.optString(TIMELINE_MODIFIED_BY_NAME, null));
             this.setDescription(json.optString(TIMELINE_DESCRIPTION, null));
-            this.setQcState(json.isNull(TIMELINE_QCSTATE) ? null : json.getInt(TIMELINE_QCSTATE));
+            // update QCState from the QCStateLabel field
+            this.setQcState(json.isNull(TIMELINE_QCSTATE_LABEL) ? null : QCStateEnum.getValueByName (c, u, QCStateEnum.getByName(json.optString(TIMELINE_QCSTATE_LABEL))));
             this.setProjectObjectId(json.optString(TIMELINE_PROJECT_OBJECT_ID, null));
             this.setProjectId(json.isNull(TIMELINE_PROJECT_ID) ? null : json.getInt(TIMELINE_PROJECT_ID));
             this.setProjectRevisionNum(json.isNull(TIMELINE_PROJECT_REVISION_NUM) ? null : json.getInt(TIMELINE_PROJECT_REVISION_NUM));
@@ -540,6 +543,7 @@ public class Timeline //extends Entity
         values.put(TIMELINE_MODIFIED_BY, getModifiedBy());
         values.put(TIMELINE_CREATED_BY_NAME, getCreatedByName());
         values.put(TIMELINE_MODIFIED_BY_NAME, getModifiedByName());
+        values.put(TIMELINE_QCSTATE_LABEL, QCStateEnum.getQCState(c, u, getQcState()).getName());
         values.put(TIMELINE_QCSTATE, getQcState());
         values.put(TIMELINE_PROJECT_OBJECT_ID, getProjectObjectId());
         values.put(TIMELINE_IS_DELETED, getDeleted());
@@ -620,6 +624,7 @@ public class Timeline //extends Entity
         json.put(TIMELINE_MODIFIED_BY, getModifiedBy());
         json.put(TIMELINE_CREATED_BY_NAME, getCreatedByName());
         json.put(TIMELINE_MODIFIED_BY_NAME, getModifiedByName());
+        json.put(TIMELINE_QCSTATE_LABEL, QCStateEnum.getQCState(c, u, getQcState()).getName());        //getQcState());
         json.put(TIMELINE_QCSTATE, getQcState());
         json.put(TIMELINE_PROJECT_OBJECT_ID, getProjectObjectId());
         json.put(TIMELINE_IS_DELETED, getDeleted());

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/security/QCStateEnum.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/security/QCStateEnum.java
@@ -67,7 +67,7 @@ public enum QCStateEnum
         _publicData = publicData;
     }
 
-    public static Integer getValueByName (Container c, User u, QCStateEnum qcStateEnum)
+    public static Integer getQCStateEnumId(Container c, User u, QCStateEnum qcStateEnum)
     {
         if (qcStateEnum == null) { return null; }
         TableInfo qcStateTable = CoreSchema.getInstance().getTableInfoDataStates();
@@ -76,18 +76,18 @@ public enum QCStateEnum
         TableSelector qcStateTs = new TableSelector(qcStateTable, cols, qcFilter, null);
         return qcStateTs.getObject(Integer.class);
     }
-    public static QCStateEnum getQCState(Container c, User u, int qcStateId)
+    public static QCStateEnum getQCStateEnumById(Container c, User u, int qcStateId)
     {
         TableInfo qcStateTable = CoreSchema.getInstance().getTableInfoDataStates();
         SimpleFilter qcFilter = SimpleFilter.createContainerFilter(c).addCondition(FieldKey.fromParts("RowId"), qcStateId, CompareType.EQUAL);
         Set<String> cols = Collections.singleton("Label");
         TableSelector qcStateTs = new TableSelector(qcStateTable, cols, qcFilter, null);
         String qcStateName = qcStateTs.getObject(String.class);
-        return QCStateEnum.getByName(qcStateName);
+        return QCStateEnum.getQCStateEnumByName(qcStateName);
     }
 
     @Nullable
-    public static QCStateEnum getByName(String name)
+    public static QCStateEnum getQCStateEnumByName(String name)
     {
         for (QCStateEnum qcStateEnum : QCStateEnum.values())
         {

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/security/QCStateEnum.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/security/QCStateEnum.java
@@ -1,6 +1,17 @@
 package org.labkey.snprc_scheduler.security;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.User;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Created by thawkins on 11/2/2018.
@@ -10,19 +21,17 @@ import org.jetbrains.annotations.Nullable;
 public enum QCStateEnum
 {
     // modeled after SND QCStates
-    COMPLETED(1, "Completed", "Record has been completed and is public", true),
-    REJECTED(2, "Rejected", "Record has been reviewed and rejected", false),
-    REVIEW_REQUIRED(3, "Review Required", "Review is required prior to public release", false),
-    IN_PROGRESS(4, "In Progress", "Draft Record, not public", false);
+    COMPLETED("Completed", "Record has been completed and is public", true),
+    REJECTED("Rejected", "Record has been reviewed and rejected", false),
+    REVIEW_REQUIRED("Review Required", "Review is required prior to public release", false),
+    IN_PROGRESS("In Progress", "Draft Record, not public", false);
 
-    private int _value;
     private String _name;
     private String _description;
     private boolean _publicData;
 
-    QCStateEnum(int value, String name, String description, boolean publicData)
+    QCStateEnum(String name, String description, boolean publicData)
     {
-        _value = value;
         _name = name;
         _description = description;
         _publicData = publicData;
@@ -58,28 +67,23 @@ public enum QCStateEnum
         _publicData = publicData;
     }
 
-    public int getValue()
+    public static Integer getValueByName (Container c, User u, QCStateEnum qcStateEnum)
     {
-        return _value;
+        if (qcStateEnum == null) { return null; }
+        TableInfo qcStateTable = CoreSchema.getInstance().getTableInfoDataStates();
+        SimpleFilter qcFilter = SimpleFilter.createContainerFilter(c).addCondition(FieldKey.fromParts("Label"), qcStateEnum.getName(), CompareType.EQUAL);
+        Set<String> cols = Collections.singleton("RowId");
+        TableSelector qcStateTs = new TableSelector(qcStateTable, cols, qcFilter, null);
+        return qcStateTs.getObject(Integer.class);
     }
-
-    public void setValue(int value)
+    public static QCStateEnum getQCState(Container c, User u, int qcStateId)
     {
-        _value = value;
-    }
-
-
-    public static Integer getValueByName (String name)
-    {
-        for (QCStateEnum qcStateEnum : QCStateEnum.values())
-        {
-            if (qcStateEnum.getName().toLowerCase().equals(name.toLowerCase()))
-            {
-                return qcStateEnum.getValue();
-            }
-        }
-
-        return null;
+        TableInfo qcStateTable = CoreSchema.getInstance().getTableInfoDataStates();
+        SimpleFilter qcFilter = SimpleFilter.createContainerFilter(c).addCondition(FieldKey.fromParts("RowId"), qcStateId, CompareType.EQUAL);
+        Set<String> cols = Collections.singleton("Label");
+        TableSelector qcStateTs = new TableSelector(qcStateTable, cols, qcFilter, null);
+        String qcStateName = qcStateTs.getObject(String.class);
+        return QCStateEnum.getByName(qcStateName);
     }
 
     @Nullable
@@ -87,12 +91,11 @@ public enum QCStateEnum
     {
         for (QCStateEnum qcStateEnum : QCStateEnum.values())
         {
-            if (qcStateEnum.getName().toLowerCase().equals(name.toLowerCase()))
+            if (qcStateEnum.getName().equalsIgnoreCase(name))
             {
                 return qcStateEnum;
             }
         }
-
         return null;
     }
 

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/services/SNPRC_schedulerServiceValidator.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/services/SNPRC_schedulerServiceValidator.java
@@ -113,7 +113,7 @@ public class SNPRC_schedulerServiceValidator
         {
             // All New Timeline, check json draft state (and other such checks here)
             //
-            if (timeline.getQcState() != null && !timeline.getQcState().equals(QCStateEnum.IN_PROGRESS.getValue()))
+            if (timeline.getQcState() != null && !timeline.getQcState().equals((QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS))))
             {
                 errors.addRowError(new ValidationException("Timeline must be created in editable Draft state")); //tested
                 throw errors;
@@ -191,7 +191,7 @@ public class SNPRC_schedulerServiceValidator
                    throw errors;
                 }
 
-                else if (!timelineRow.get(Timeline.TIMELINE_QCSTATE ).equals(QCStateEnum.IN_PROGRESS.getValue()))
+                else if (!timelineRow.get(Timeline.TIMELINE_QCSTATE ).equals(QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS)))
                 {
                     // only admins and reviewers can change QCState
                     if (!c.hasPermission(u, SNPRC_schedulerReviewersPermission.class) && !c.hasPermission(u, SNPRC_schedulerAdminPermission.class))

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/services/SNPRC_schedulerServiceValidator.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/services/SNPRC_schedulerServiceValidator.java
@@ -113,7 +113,7 @@ public class SNPRC_schedulerServiceValidator
         {
             // All New Timeline, check json draft state (and other such checks here)
             //
-            if (timeline.getQcState() != null && !timeline.getQcState().equals(QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS)))
+            if (timeline.getQcState() != null && !timeline.getQcState().equals(QCStateEnum.getQCStateEnumId(c,u, QCStateEnum.IN_PROGRESS)))
             {
                 errors.addRowError(new ValidationException("Timeline must be created in editable Draft state")); //tested
                 throw errors;
@@ -191,7 +191,7 @@ public class SNPRC_schedulerServiceValidator
                    throw errors;
                 }
 
-                else if (!timelineRow.get(Timeline.TIMELINE_QCSTATE ).equals(QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS)))
+                else if (!timelineRow.get(Timeline.TIMELINE_QCSTATE ).equals(QCStateEnum.getQCStateEnumId(c,u, QCStateEnum.IN_PROGRESS)))
                 {
                     // only admins and reviewers can change QCState
                     if (!c.hasPermission(u, SNPRC_schedulerReviewersPermission.class) && !c.hasPermission(u, SNPRC_schedulerAdminPermission.class))

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/services/SNPRC_schedulerServiceValidator.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/services/SNPRC_schedulerServiceValidator.java
@@ -113,7 +113,7 @@ public class SNPRC_schedulerServiceValidator
         {
             // All New Timeline, check json draft state (and other such checks here)
             //
-            if (timeline.getQcState() != null && !timeline.getQcState().equals((QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS))))
+            if (timeline.getQcState() != null && !timeline.getQcState().equals(QCStateEnum.getValueByName(c,u, QCStateEnum.IN_PROGRESS)))
             {
                 errors.addRowError(new ValidationException("Timeline must be created in editable Draft state")); //tested
                 throw errors;

--- a/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/TimelineScripts.java
+++ b/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/TimelineScripts.java
@@ -70,7 +70,7 @@ public class TimelineScripts
                 "        'RC' : 'Mouse, Mikey',\n" +
                 "        'Notes' : 'Dont take any wooden nickels.',\n" +
                 "        'AnimalAccount' : '4815162342',\n" +
-                "        'QcState' : 4,\n" +                        // In-Progress
+                "        'QcStateLabel' : 'In Progress',\n" +
         /*
                 Add TimelineItems
          */


### PR DESCRIPTION
#### Rationale
Snprc_scheduler should use the same QcStates as the SND module

#### Changes
- Refactor Timeline.java to include QCStateLabel values in the map and json methods so the data is included with API calls
- removed integer values from the QCStateEnum - these values are looked up from the core.DataStates table. They are added to 
  the table by the SND module.
- refactored validator to use new enum methods
- updated schema version to 23.00
- Removed unused QcState column from snprc_scheduler.StudyDayNotes table
- Added FK metadata to QcState column in Timeline table
- Refactored client code to use QCStateLabels instead of values

