### PR TITLE
Handle Widget Modal Closing on Submit or Cancel

### DIFF
--- a/snprc_ehr/resources/queries/study/availableChargeIds.sql
+++ b/snprc_ehr/resources/queries/study/availableChargeIds.sql
@@ -6,14 +6,15 @@ PARAMETERS (
 -- Research Charge IDs
 SELECT
     CAST(p.project AS VARCHAR(40)) AS admitProjectId,
-    p.project AS projectId,
-    sp.projectType AS projectType,
+    p.project AS ehrProjectId,
+    sp.projectType AS sndProjectType,
+    sp.ObjectId AS sndProjectObjectId,
     0 AS admitId,
     sp.description AS projectText,
     GREATEST (p.startDate, aaa.date, sp.startDate) AS startDate,
     LEAST (p.endDate, TIMESTAMPADD('SQL_TSI_DAY', 1, aaa.endDate), TIMESTAMPADD('SQL_TSI_DAY', 1, sp.endDate), NOW()) AS endDate,
-    sp.projectId AS projectId,
-    sp.revisionNum AS revisionNum
+    sp.projectId AS sndProjectId,
+    sp.revisionNum AS sndRevisionNum
 FROM ehr.project AS p
          INNER JOIN snd.projects AS sp ON p.project = sp.referenceId
          INNER JOIN study.assignment aaa ON p.protocol = aaa.protocol AND aaa.assignmentStatus IN ( 'A', 'S')
@@ -24,14 +25,15 @@ WHERE aaa.id = ANIMAL_ID
 UNION
 SELECT DISTINCT
     CAST(p.project AS varchar(40)) AS admitProjectId,
-    p.project AS projectId,
-    sp.projectType AS projectType,
+    p.project AS ehrProjectId,
+    sp.projectType AS sndProjectType,
+    sp.ObjectId AS sndProjectObjectId,
     0 AS admitId,
     sp.description AS projectText,
     GREATEST (p.startDate, sp.startDate) AS startDate,
     LEAST (p.endDate, TIMESTAMPADD('SQL_TSI_DAY', 1, sp.endDate), NOW()) AS endDate,
-    sp.projectId AS projectId,
-    sp.revisionNum AS revisionNum
+    sp.projectId AS sndProjectId,
+    sp.revisionNum AS sndRevisionNum
 FROM snprc_ehr.validChargeBySpecies AS vcbs
          INNER JOIN ehr.project AS p ON p.project = vcbs.project
          INNER JOIN study.demographics AS d ON d.id = ANIMAL_ID
@@ -43,14 +45,15 @@ WHERE d.id = ANIMAL_ID AND vcbs.species = d.species.arc_species_code
 UNION
 SELECT DISTINCT
     CAST(c.caseid AS varchar(40)) AS admitProjectId,
-    p.project AS projectId,
-    sp.projectType AS projectType,
+    p.project AS ehrProjectId,
+    sp.projectType AS sndProjectType,
+    sp.ObjectId AS sndProjectObjectId,
     c.caseid AS admitId,
     c.problem + '/' + c.admitcomplaint AS projectText,
     GREATEST (c.date, sp.startDate) AS startDate,
     LEAST (c.enddate, TIMESTAMPADD('SQL_TSI_DAY', 1, sp.endDate), NOW()) AS endDate,
-    sp.projectId AS projectId,
-    sp.revisionNum AS revisionNum
+    sp.projectId AS sndProjectId,
+    sp.revisionNum AS sndRevisionNum
 FROM study.cases AS c
          INNER JOIN study.demographics AS d ON c.id = ANIMAL_ID
          INNER JOIN snprc_ehr.validChargeBySpecies AS vcbs ON c.id = ANIMAL_ID AND vcbs.species = d.species.arc_species_code

--- a/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useState, useEffect } from 'react';
 import { EventListingGridPanel } from './components/EventListingGridPanel';
-import './styles/sndEventsWidget.scss'
-import { FormGroup, ControlLabel, FormControl } from 'react-bootstrap'
+import './styles/sndEventsWidget.scss';
+import { FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
 import { getMultiRow } from './actions';
 import { Alert } from '@labkey/components';
 
@@ -22,26 +22,26 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
                 await getSubjectIdsFromFilters(filterConfig, setSubjectIds);
             }
         })();
-    }, [])
+    }, []);
 
 
     const handleEnter = (e) => {
-        setSubjectIds(e.target.value.split(";"))
-    }
+        setSubjectIds(e.target.value.split(';'));
+    };
 
     const handleError = (message: string) => {
         setMessage(message);
         window.setTimeout(() => setMessage(undefined), 30000);
-    }
+    };
 
     const handleUpdateResponse = (message: string, status: string) => {
         setMessage(message);
-        setStatus(status)
+        setStatus(status);
         window.setTimeout(() => setMessage(undefined), 30000);
-    }
+    };
 
     const form = () => {
-        return(
+        return (
             <div>
                 <form onSubmit={handleEnter}>
                     <FormGroup className={'subjectId-form'} htmlFor={'standaloneId'}>
@@ -51,13 +51,13 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
                                      type={'text'}
                                      placeholder={`Enter Subject ID`}
                                      required={true}
-                                     onChange={(e: any) => setSubjectIds(e.target.value.split(";"))}
+                                     onChange={(e: any) => setSubjectIds(e.target.value.split(';'))}
                         />
                     </FormGroup>
                 </form>
             </div>
-        )
-    }
+        );
+    };
 
     return (
         <div>
@@ -75,28 +75,29 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
                 <Alert>No animals were found for filter selections</Alert>
             )}
             {message && (
-                <Alert bsStyle={status} >{message}</Alert>
+                <Alert bsStyle={status}>{message}</Alert>
             )}
             {hasPermission && subjectIds && (
                 <EventListingGridPanel subjectIDs={subjectIds} onChange={handleUpdateResponse} onError={handleError}/>
             )}
 
         </div>
-    )
-})
+    );
+});
 
 const getSubjectIdsFromFilters = async (filterConfig, handleSetSubjectIds) => {
     const subjectIds = [];
     const filters = filterConfig.filters;
     if (filters.inputType === 'roomCage' && filters.room !== null) {
         const rooms = filters.room.split(',');
-        let ids: string[]
+        let ids: string[];
         try {
             ids = (await getMultiRow('study', 'demographicsCurLocation', 'room', rooms, []))['rows'].map(a => a.Id);
-        } catch (err) {
+        }
+        catch (err) {
             console.log(err);
         }
-        handleSetSubjectIds(ids.length ? ids : ['none'])
+        handleSetSubjectIds(ids.length ? ids : ['none']);
     } else if (filters.inputType === 'multiSubject') {
         const ids = filters.nonRemovable['0'] ? filters.nonRemovable['0'].value : ['none'];
         handleSetSubjectIds(Array.isArray(ids) ? ids : [ids]);
@@ -105,4 +106,4 @@ const getSubjectIdsFromFilters = async (filterConfig, handleSetSubjectIds) => {
         subjectIds.push(ids);
         handleSetSubjectIds(subjectIds);
     }
-}
+};

--- a/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
@@ -13,6 +13,7 @@ interface Props {
 export const SndEventsWidget: FC<Props> = memo((props: Props) => {
     const {filterConfig, hasPermission} = props;
     const [subjectIds, setSubjectIds] = useState<string[]>(['']);
+    const [successMessage, setSuccessMessage] = useState<string>(undefined);
 
     useEffect(() => {
         (async () => {
@@ -25,6 +26,11 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
 
     const handleEnter = (e) => {
         setSubjectIds(e.target.value.split(";"))
+    }
+
+    const handleUpdateSuccess = (message: string) => {
+        setSuccessMessage(message);
+        window.setTimeout(() => setSuccessMessage(undefined), 10000);
     }
 
     const form = () => {
@@ -61,8 +67,11 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
             {hasPermission && subjectIds[0] === 'none' && (
                 <Alert>No animals were found for filter selections</Alert>
             )}
+            {successMessage && (
+                <Alert bsStyle="success" >{successMessage}</Alert>
+            )}
             {hasPermission && subjectIds && (
-                <EventListingGridPanel subjectIDs={subjectIds} />
+                <EventListingGridPanel subjectIDs={subjectIds} onChange={handleUpdateSuccess}/>
             )}
 
         </div>

--- a/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
@@ -13,7 +13,8 @@ interface Props {
 export const SndEventsWidget: FC<Props> = memo((props: Props) => {
     const {filterConfig, hasPermission} = props;
     const [subjectIds, setSubjectIds] = useState<string[]>(['']);
-    const [successMessage, setSuccessMessage] = useState<string>(undefined);
+    const [message, setMessage] = useState<string>(undefined);
+    const [status, setStatus] = useState<string>(undefined);
 
     useEffect(() => {
         (async () => {
@@ -28,9 +29,15 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
         setSubjectIds(e.target.value.split(";"))
     }
 
-    const handleUpdateSuccess = (message: string) => {
-        setSuccessMessage(message);
-        window.setTimeout(() => setSuccessMessage(undefined), 10000);
+    const handleError = (message: string) => {
+        setMessage(message);
+        window.setTimeout(() => setMessage(undefined), 30000);
+    }
+
+    const handleUpdateResponse = (message: string, status: string) => {
+        setMessage(message);
+        setStatus(status)
+        window.setTimeout(() => setMessage(undefined), 30000);
     }
 
     const form = () => {
@@ -67,11 +74,11 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
             {hasPermission && subjectIds[0] === 'none' && (
                 <Alert>No animals were found for filter selections</Alert>
             )}
-            {successMessage && (
-                <Alert bsStyle="success" >{successMessage}</Alert>
+            {message && (
+                <Alert bsStyle={status} >{message}</Alert>
             )}
             {hasPermission && subjectIds && (
-                <EventListingGridPanel subjectIDs={subjectIds} onChange={handleUpdateSuccess}/>
+                <EventListingGridPanel subjectIDs={subjectIds} onChange={handleUpdateResponse} onError={handleError}/>
             )}
 
         </div>

--- a/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/SndEventsWidget.tsx
@@ -31,6 +31,7 @@ export const SndEventsWidget: FC<Props> = memo((props: Props) => {
 
     const handleError = (message: string) => {
         setMessage(message);
+        setStatus("danger");
         window.setTimeout(() => setMessage(undefined), 30000);
     };
 

--- a/snprc_ehr/src/client/SndEventsWidget/components/AdmissionInfoPopover.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/AdmissionInfoPopover.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export const AdmissionInfoPopover: FC<Props> = memo((props: Props) => {
-    const { admitChargeId, eventId } = props;
+    const {admitChargeId, eventId} = props;
 
     const [admissionInfo, setAdmissionInfo] = useState<JSX.Element[]>([]);
 
@@ -16,19 +16,19 @@ export const AdmissionInfoPopover: FC<Props> = memo((props: Props) => {
 
     const handlePopoverEnter = async () => {
         await getAdmitData(eventId, setAdmissionInfo);
-    }
+    };
 
     const popover = (
-        <Popover className={"charge-id-popover"} id={"charge-id-popover"} >
+        <Popover className={'charge-id-popover'} id={'charge-id-popover'}>
             <div>
                 <h4><strong>Admission Information</strong></h4>
                 {admissionInfo.map((d, i) => {
-                    return <div key={i}>{d}</div>
+                    return <div key={i}>{d}</div>;
                 })}
             </div>
         </Popover>
-    )
-    return(
+    );
+    return (
         <OverlayTrigger
             ref={r => (ref = r)}
             container={ref.current}
@@ -38,8 +38,8 @@ export const AdmissionInfoPopover: FC<Props> = memo((props: Props) => {
             shouldUpdatePosition={true}>
             <span>{admitChargeId}</span>
         </OverlayTrigger>
-    )
-})
+    );
+});
 
 const getAdmitData = async (admitEventId, handleSetAdmissionInfo) => {
 
@@ -49,24 +49,24 @@ const getAdmitData = async (admitEventId, handleSetAdmissionInfo) => {
         display.push(<span><strong>Admit ID:</strong> <i>{info['AdmitId']}</i></span>,
             <span><strong>Diagnosis:</strong> <i>{info['Diagnosis']}</i></span>,
             <span><strong>Admitting complaint:</strong> <i>{info['AdmittingComplaint']}</i></span>,
-            <span><strong>Admission date:</strong> <i>{info['AdmitDate'] === null ? 'Not recorded' : info['AdmitDate'].split(" ")[0]}</i></span>)
+            <span><strong>Admission date:</strong> <i>{info['AdmitDate'] === null ? 'Not recorded' : info['AdmitDate'].split(' ')[0]}</i></span>);
 
         if (info['ReleaseDate'] != null) {
-            display.push(<span><strong>Release date:</strong> <i>{info['ReleaseDate'].split(" ")[0]}</i></span>)
+            display.push(<span><strong>Release date:</strong> <i>{info['ReleaseDate'].split(' ')[0]}</i></span>);
         }
         if (info['Resolution'] != null) {
-            display.push(<span><strong>Resolution:</strong> <i>{info['Resolution']}</i></span>)
+            display.push(<span><strong>Resolution:</strong> <i>{info['Resolution']}</i></span>);
         }
     } else {
-        display.push(<span><strong>Charge ID:</strong> <i>{info['ChargeId']}</i></span>)
+        display.push(<span><strong>Charge ID:</strong> <i>{info['ChargeId']}</i></span>);
         if (info['Protocol'] != null) {
             display.push(<span><strong>IACUC #:</strong> <i>{info['Protocol']}</i></span>,
                 <span><strong>IACUC Description:</strong> <i>{info['IacucDescription']}</i></span>,
-                <span><strong>IACUC Assignment Date:</strong> <i>{(info['AssignmentDate'] === null ? 'Not found' : info['AssignmentDate'].split(" ")[0])}</i></span>,
-                <span><strong>Supervising Vet:</strong> <i>{(info['Veterinarian'] === null ? 'Not recorded' : info['Veterinarian'])}</i></span>)
+                <span><strong>IACUC Assignment Date:</strong> <i>{(info['AssignmentDate'] === null ? 'Not found' : info['AssignmentDate'].split(' ')[0])}</i></span>,
+                <span><strong>Supervising Vet:</strong> <i>{(info['Veterinarian'] === null ? 'Not recorded' : info['Veterinarian'])}</i></span>);
         } else {
-            display.push(<span><strong>Description:</strong> <i>{info['Description']}</i></span>)
+            display.push(<span><strong>Description:</strong> <i>{info['Description']}</i></span>);
         }
     }
     handleSetAdmissionInfo(display);
-}
+};

--- a/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
@@ -103,8 +103,6 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
         } else if (message) {
             closeDialog();
             onError(message);
-        } else {
-            closeDialog();
         }
     };
 
@@ -162,7 +160,7 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
                 />
             )}
             {showDialog === 'edit' && (
-                <ProcedureEntryModal onCancel={handleCloseUpdateModal}
+                <ProcedureEntryModal onCancel={closeDialog}
                                      onError={handleCloseUpdateModal}
                                      onComplete={handleCloseUpdateModal}
                                      eventId={eventID}

--- a/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
@@ -20,7 +20,7 @@ interface EventListingProps {
 }
 
 export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: EventListingProps & InjectedQueryModels) => {
-    const { subjectIDs, actions, queryModels, onChange, onError } = props;
+    const {subjectIDs, actions, queryModels, onChange, onError} = props;
 
     const [showDialog, setShowDialog] = useState<string>('');
     const [eventID, setEventID] = useState<string>('');
@@ -32,22 +32,22 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
                 const {queryInfo} = queryModels[subjectIDs[0]];
                 if (queryInfo) {
                     const queryCols = new ExtendedMap<string, QueryColumn>();
-                    queryInfo.columns.forEach( (column, key) => {
+                    queryInfo.columns.forEach((column, key) => {
                         if ((column.name === 'HTMLNarrative')) {
-                            const htmlCol = new QueryColumn({...column, ...{"cell": htmlRenderer}});
+                            const htmlCol = new QueryColumn({...column, ...{'cell': htmlRenderer}});
                             queryCols.set(key, htmlCol);
                         } else if ((column.name === 'SubjectId')) {
-                            const editCol = new QueryColumn({...column, ...{"cell": editButtonRenderer}});
+                            const editCol = new QueryColumn({...column, ...{'cell': editButtonRenderer}});
                             queryCols.set(key, editCol);
                         } else if ((column.name === 'AdmitChargeId')) {
-                            const admitCol = new QueryColumn({...column, ...{"cell": admitChargeIdPopoverRenderer}});
+                            const admitCol = new QueryColumn({...column, ...{'cell': admitChargeIdPopoverRenderer}});
                             queryCols.set(key, admitCol);
                         } else {
                             queryCols.set(key, column);
                         }
                     });
 
-                    const newQueryInfo = new QueryInfo({...queryInfo, ...{"columns": queryCols}});
+                    const newQueryInfo = new QueryInfo({...queryInfo, ...{'columns': queryCols}});
 
                     // Update QueryModel with new QueryInfo
                     setQueryModel(
@@ -57,7 +57,7 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
                     );
                 }
             }
-        })()
+        })();
 
     }, [queryModels[subjectIDs[0]]]);
 
@@ -85,9 +85,9 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
 
     const htmlRenderer = (data) => {
         return (
-            <div dangerouslySetInnerHTML={{__html: data.get('value')}} />
+            <div dangerouslySetInnerHTML={{__html: data.get('value')}}/>
         );
-    }
+    };
 
     const handleClick = (value) => {
         // Code to run when the button is clicked
@@ -97,7 +97,7 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
 
     const handleCloseUpdateModal = (message?: string, status?: string) => {
         if (message && status) {
-            actions.loadModel(subjectIDs[0])
+            actions.loadModel(subjectIDs[0]);
             closeDialog();
             onChange(message, status);
         } else if (message) {
@@ -106,26 +106,28 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
         } else {
             closeDialog();
         }
-    }
+    };
 
     const editButtonRenderer = (data, row) => {
         return (
             <div>
                 <span>{data.get('value')} </span>
-                <button className={"pencil-btn"} onClick={function() { handleClick(row.get('EventId').get('value')) }}>
-                    <i className={"fa fa-pencil"}></i>
+                <button className={'pencil-btn'} onClick={function () {
+                    handleClick(row.get('EventId').get('value'));
+                }}>
+                    <i className={'fa fa-pencil'}></i>
                 </button>
             </div>
         );
-    }
+    };
 
     const admitChargeIdPopoverRenderer = (data, row) => {
         const admitChargeId = data.get('value');
         const eventId = row.get('EventId').get('value');
         return (
-            <AdmissionInfoPopover admitChargeId={admitChargeId} eventId={eventId} />
-        )
-    }
+            <AdmissionInfoPopover admitChargeId={admitChargeId} eventId={eventId}/>
+        );
+    };
 
     /**
      * Render the custom buttons that will be displayed on the grid
@@ -133,7 +135,8 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
     const renderButtons = () => {
         return (
             <div className="manage-buttons">
-                {<Button disabled={subjectIDs.length != 1} bsStyle={'success'} onClick={() => toggleDialog('create')} >
+                {<Button disabled={true /*subjectIDs.length != 1*/} bsStyle={'success'}
+                         onClick={() => toggleDialog('create')}>
                     New
                 </Button>}
             </div>
@@ -144,7 +147,7 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
         <div>
             {queryModel?.queryInfo && (
                 <GridPanel model={queryModel}
-                           title={"Events for Animal(s) " + subjectIDs.join(', ')}
+                           title={'Events for Animal(s) ' + subjectIDs.join(', ')}
                            actions={actions}
                            highlightLastSelectedRow={true}
                            showPagination={true}
@@ -175,13 +178,13 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
             )}
 
         </div>
-    )
+    );
 });
 
 const EventListingGridPanelWithModels = withQueryModels<EventListingProps>(EventListingGridPanelImpl);
 
-export const EventListingGridPanel: FC<EventListingProps> = memo((props: EventListingProps ) => {
-    const { subjectIDs } = props;
+export const EventListingGridPanel: FC<EventListingProps> = memo((props: EventListingProps) => {
+    const {subjectIDs} = props;
 
     const queryConfigs: QueryConfigMap = useMemo(
         () => ({

--- a/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
@@ -129,7 +129,7 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
     const renderButtons = () => {
         return (
             <div className="manage-buttons">
-                {<Button disabled={true /*subjectIDs.length != 1*/} bsStyle={'success'} onClick={() => toggleDialog('create')} >
+                {<Button disabled={subjectIDs.length != 1} bsStyle={'success'} onClick={() => toggleDialog('create')} >
                     New
                 </Button>}
             </div>

--- a/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
@@ -14,11 +14,12 @@ import { ProcedureEntryModal } from './ProcedureEntryModal';
 import { AdmissionInfoPopover } from './AdmissionInfoPopover';
 
 interface EventListingProps {
-    subjectIDs: string[]
+    subjectIDs: string[],
+    onChange: (message: string) => any
 }
 
 export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: EventListingProps & InjectedQueryModels) => {
-    const { subjectIDs, actions, queryModels } = props;
+    const { subjectIDs, actions, queryModels, onChange } = props;
 
     const [showDialog, setShowDialog] = useState<string>('');
     const [eventID, setEventID] = useState<string>('');
@@ -93,6 +94,16 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
         toggleDialog('edit');
     };
 
+    const handleCloseUpdateModal = (message?: string) => {
+        if (message) {
+            actions.loadModel(subjectIDs[0])
+            closeDialog();
+            onChange(message);
+        } else {
+            closeDialog();
+        }
+    }
+
     const editButtonRenderer = (data, row) => {
         return (
             <div>
@@ -118,8 +129,7 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
     const renderButtons = () => {
         return (
             <div className="manage-buttons">
-                {/*{<Button disabled={subjectIDs.length != 1} bsStyle={'success'} onClick={() => toggleDialog('create')} >*/}
-                {<Button disabled={true} bsStyle={'success'} onClick={() => toggleDialog('create')} >
+                {<Button disabled={true /*subjectIDs.length != 1*/} bsStyle={'success'} onClick={() => toggleDialog('create')} >
                     New
                 </Button>}
             </div>
@@ -145,13 +155,14 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
                 />
             )}
             {showDialog === 'edit' && (
-                <ProcedureEntryModal onCancel={closeDialog}
+                <ProcedureEntryModal onCancel={handleCloseUpdateModal}
+                                     onSuccess={handleCloseUpdateModal}
                                      eventId={eventID}
                                      show={showDialog === 'edit'}
                 />
             )}
             {showDialog === 'create' && (
-                <ProcedureEntryModal show={showDialog === 'create'} onCancel={closeDialog} subjectId={subjectIDs[0]}/>
+                <ProcedureEntryModal show={showDialog === 'create'} onCancel={closeDialog} onSuccess={handleCloseUpdateModal} subjectId={subjectIDs[0]}/>
             )}
 
         </div>

--- a/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
@@ -133,7 +133,7 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
     const renderButtons = () => {
         return (
             <div className="manage-buttons">
-                {<Button disabled={subjectIDs.length != 1} bsStyle={'success'} onClick={() => toggleDialog('create')} >
+                {<Button disabled={true /*subjectIDs.length != 1*/} bsStyle={'success'} onClick={() => toggleDialog('create')} >
                     New
                 </Button>}
             </div>

--- a/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/EventListingGridPanel.tsx
@@ -15,11 +15,12 @@ import { AdmissionInfoPopover } from './AdmissionInfoPopover';
 
 interface EventListingProps {
     subjectIDs: string[],
-    onChange: (message: string) => any
+    onChange: (message: string, status: string) => any,
+    onError: (message: string) => any
 }
 
 export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: EventListingProps & InjectedQueryModels) => {
-    const { subjectIDs, actions, queryModels, onChange } = props;
+    const { subjectIDs, actions, queryModels, onChange, onError } = props;
 
     const [showDialog, setShowDialog] = useState<string>('');
     const [eventID, setEventID] = useState<string>('');
@@ -94,11 +95,14 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
         toggleDialog('edit');
     };
 
-    const handleCloseUpdateModal = (message?: string) => {
-        if (message) {
+    const handleCloseUpdateModal = (message?: string, status?: string) => {
+        if (message && status) {
             actions.loadModel(subjectIDs[0])
             closeDialog();
-            onChange(message);
+            onChange(message, status);
+        } else if (message) {
+            closeDialog();
+            onError(message);
         } else {
             closeDialog();
         }
@@ -156,13 +160,18 @@ export const EventListingGridPanelImpl: FC<EventListingProps> = memo((props: Eve
             )}
             {showDialog === 'edit' && (
                 <ProcedureEntryModal onCancel={handleCloseUpdateModal}
-                                     onSuccess={handleCloseUpdateModal}
+                                     onError={handleCloseUpdateModal}
+                                     onComplete={handleCloseUpdateModal}
                                      eventId={eventID}
                                      show={showDialog === 'edit'}
                 />
             )}
             {showDialog === 'create' && (
-                <ProcedureEntryModal show={showDialog === 'create'} onCancel={closeDialog} onSuccess={handleCloseUpdateModal} subjectId={subjectIDs[0]}/>
+                <ProcedureEntryModal show={showDialog === 'create'}
+                                     onCancel={closeDialog}
+                                     onError={handleCloseUpdateModal}
+                                     onComplete={handleCloseUpdateModal}
+                                     subjectId={subjectIDs[0]}/>
             )}
 
         </div>

--- a/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
@@ -1,6 +1,5 @@
-import React, { FC, memo, useEffect, useState } from 'react';
+import React, { FC, memo, useEffect } from 'react';
 import { Modal } from 'react-bootstrap';
-import { Alert } from '@labkey/components';
 
 interface Props {
     show: boolean,

--- a/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
@@ -5,11 +5,12 @@ import { Alert } from '@labkey/components';
 interface Props {
     show: boolean,
     onCancel: () => any,
+    onSuccess: (message) => any,
     eventId?: string,
     subjectId?: string
 }
 export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
-    const { show, onCancel, eventId, subjectId } = props;
+    const { show, onCancel, onSuccess, eventId, subjectId } = props;
 
     useEffect(() => {
         const script = document.createElement('script');
@@ -23,7 +24,22 @@ export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
             } else if (subjectId) {
                 ProcedureEntryWidget.setAttribute('data-subject-id', subjectId)
             }
+            window.addEventListener('saveEventSuccess', handleSaveEventSuccess);
+
         }
+
+        const handleBodyClick = (event: Event) => {
+            let targetElement = event.target as HTMLElement; // Casting to HTMLElement
+            if (targetElement && (targetElement.className.includes("widget-cancel") || targetElement.parentElement.className.includes("widget-cancel"))) {
+                onCancel();
+            }
+        };
+
+        const handleSaveEventSuccess = (event) => {
+            onSuccess(event.detail.message);
+        }
+
+        document.body.addEventListener('click', handleBodyClick);
 
         document.getElementById("modal-body").insertBefore(script, document.getElementById("modal-body").firstChild)
 
@@ -36,7 +52,7 @@ export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
 
 
     return (
-        <Modal id="widget-modal" className="widget-modal" show={show} onHide={onCancel} >
+        <Modal backdrop="static" keyboard={false} id="widget-modal" className="widget-modal" show={show} onHide={onCancel} >
             <Modal.Body id="modal-body" className="widget-modal-body">
                 {eventId && (
                     <div id="procedure-entry-widget" data-event-id={eventId}></div>

--- a/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
@@ -5,12 +5,13 @@ import { Alert } from '@labkey/components';
 interface Props {
     show: boolean,
     onCancel: () => any,
-    onSuccess: (message) => any,
+    onComplete: (message, status) => any,
+    onError: (message) => any,
     eventId?: string,
     subjectId?: string
 }
 export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
-    const { show, onCancel, onSuccess, eventId, subjectId } = props;
+    const { show, onCancel, onComplete, onError, eventId, subjectId } = props;
 
     useEffect(() => {
         const script = document.createElement('script');
@@ -24,8 +25,8 @@ export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
             } else if (subjectId) {
                 ProcedureEntryWidget.setAttribute('data-subject-id', subjectId)
             }
-            window.addEventListener('saveEventSuccess', handleSaveEventSuccess);
-
+            window.addEventListener('saveEventComplete', handleSaveEventComplete);
+            window.addEventListener('widgetDataError', handleWidgetDataError);
         }
 
         const handleBodyClick = (event: Event) => {
@@ -35,8 +36,12 @@ export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
             }
         };
 
-        const handleSaveEventSuccess = (event) => {
-            onSuccess(event.detail.message);
+        const handleSaveEventComplete = (event) => {
+            onComplete(event.detail.message, event.detail.status);
+        }
+
+        const handleWidgetDataError = (event) => {
+            onError(event.detail.message);
         }
 
         document.body.addEventListener('click', handleBodyClick);

--- a/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
+++ b/snprc_ehr/src/client/SndEventsWidget/components/ProcedureEntryModal.tsx
@@ -10,54 +10,55 @@ interface Props {
     eventId?: string,
     subjectId?: string
 }
+
 export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
-    const { show, onCancel, onComplete, onError, eventId, subjectId } = props;
+    const {show, onCancel, onComplete, onError, eventId, subjectId} = props;
 
     useEffect(() => {
         const script = document.createElement('script');
-        script.src = '/labkey/snprc_mobile/app/widget.js'
-        script.type = 'application/javascript'
+        script.src = '/labkey/snprc_mobile/app/widget.js';
+        script.type = 'application/javascript';
 
         script.onload = () => {
-            const ProcedureEntryWidget = document.getElementById('procedure-entry-widget')
+            const ProcedureEntryWidget = document.getElementById('procedure-entry-widget');
             if (eventId) {
-                ProcedureEntryWidget.setAttribute('data-event-id', eventId)
+                ProcedureEntryWidget.setAttribute('data-event-id', eventId);
             } else if (subjectId) {
-                ProcedureEntryWidget.setAttribute('data-subject-id', subjectId)
+                ProcedureEntryWidget.setAttribute('data-subject-id', subjectId);
             }
             window.addEventListener('saveEventComplete', handleSaveEventComplete);
             window.addEventListener('widgetDataError', handleWidgetDataError);
-        }
+        };
 
         const handleBodyClick = (event: Event) => {
             let targetElement = event.target as HTMLElement; // Casting to HTMLElement
-            if (targetElement && (targetElement.className.includes("widget-cancel") || targetElement.parentElement.className.includes("widget-cancel"))) {
+            if (targetElement && (targetElement.className.includes('widget-cancel') || (targetElement.parentElement && targetElement.parentElement.className.includes('widget-cancel')))) {
                 onCancel();
             }
         };
 
         const handleSaveEventComplete = (event) => {
             onComplete(event.detail.message, event.detail.status);
-        }
+        };
 
         const handleWidgetDataError = (event) => {
             onError(event.detail.message);
-        }
+        };
 
         document.body.addEventListener('click', handleBodyClick);
 
-        document.getElementById("modal-body").insertBefore(script, document.getElementById("modal-body").firstChild)
+        document.getElementById('modal-body').insertBefore(script, document.getElementById('modal-body').firstChild);
 
         return () => {
-            document.getElementById("modal-body").removeChild(script);
+            document.getElementById('modal-body').removeChild(script);
         };
 
-    }, [])
-
+    }, []);
 
 
     return (
-        <Modal backdrop="static" keyboard={false} id="widget-modal" className="widget-modal" show={show} onHide={onCancel} >
+        <Modal backdrop="static" keyboard={false} id="widget-modal" className="widget-modal" show={show}
+               onHide={onCancel}>
             <Modal.Body id="modal-body" className="widget-modal-body">
                 {eventId && (
                     <div id="procedure-entry-widget" data-event-id={eventId}></div>
@@ -67,5 +68,5 @@ export const ProcedureEntryModal: FC<Props> = memo((props: Props) => {
                 )}
             </Modal.Body>
         </Modal>
-    )
+    );
 });


### PR DESCRIPTION
- Added event listeners for Success and Cancel in Procedure Entry Widget
- Added grid reload for successful Event Update
- Added functionality for closing the modal on success, cancel, and error
- Added Alerts for successful event updates, event update errors, server errors, and widget client errors

Related JIRA Issue:

* https://txbiomed.atlassian.net/browse/MDP-61?atlOrigin=eyJpIjoiNzE5OGQxZjQ5ZDA0NDU3M2I1ZTQ2OGYxZjcyYzZiZWIiLCJwIjoiaiJ9

Related PR:
* https://github.com/SNPRC/snprc_mobile/pull/269