### PR TITLE
Fixed bad metadata for treatment_order dataset

### DIFF
--- a/snprc_ehr/resources/queries/study/treatment_order.query.xml
+++ b/snprc_ehr/resources/queries/study/treatment_order.query.xml
@@ -61,7 +61,8 @@
                         <fk>
                             <fkDbSchema>ehr_lookups</fkDbSchema>
                             <fkTable>treatment_frequency</fkTable>
-                            <fkColumnName>short_name</fkColumnName>
+                            <fkColumnName>rowid</fkColumnName>
+                            <fkDisplayColumnName>shortname</fkDisplayColumnName>
                         </fk>
                     </column>
                     <column columnName="route">


### PR DESCRIPTION
#### Rationale
Bug fix in study.treatment_order FK display

[Issue 336: Therapy frequency is not displaying properly in study.treatment_order dataset](https://vger.txbiomed.org/labkey/SNPRC/Issue%20Tracker/issues-details.view?issueId=336)