### PR TITLE
Update entryPoints.js to use permissionClasses instead of permission property

### DIFF
--- a/snprc_ehr/src/client/entryPoints.js
+++ b/snprc_ehr/src/client/entryPoints.js
@@ -7,35 +7,35 @@ module.exports = {
     apps: [{
         name: 'NewAnimalPage',
         title: 'New Animal Wizard',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/NewAnimalPage'
     }, {
         name: 'BirthRecordReport',
         title: 'Birth Record Report',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/BirthRecordReport'
     }, {
         name: 'ChipReader',
         title: 'Chip Reader',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/ChipReader'
     },
         {
             name: 'SsrsReporting',
             title: 'PDF Reports',
-            permission: 'read',
+            permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
             path: './src/client/SsrsReporting'
         },
         {
             name: 'SndLookupsManagement',
             title: 'SND Lookups Management',
-            permission: 'read',
+            permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
             path: './src/client/SndLookupsManagement'
         },
         {
             name: 'SndEventsWidget',
             title: 'Animal Events',
-            permission: 'read',
+            permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
             path: './src/client/SndEventsWidget'
         },
         {

--- a/snprc_ehr/src/client/entryPoints.js
+++ b/snprc_ehr/src/client/entryPoints.js
@@ -41,7 +41,6 @@ module.exports = {
         {
             name: 'SndEventsWidgetWebpart',
             title: 'Animal Events Webpart',
-            permission: 'read',
             path: './src/client/SndEventsWidget/webpart',
             generateLib: true
         }


### PR DESCRIPTION
#### Rationale
We are deprecating the `<permissions>` properties for the view.xml files. This PR migrates those usages to `<permissionClasses>`.

#### Changes
- Update entryPoints.js to use permissionClasses instead of permission property
- Remove entryPoints.js permission props for generateLib since they don't apply for libs
