### PR TITLE
Migrate <permission name="login"/> to <requiresLogin/>

### DIFF
--- a/snprc_scheduler/resources/views/app.view.xml
+++ b/snprc_scheduler/resources/views/app.view.xml
@@ -1,7 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="none" title="Procedure scheduling">
-    <permissions>
-        <permission name="login"/>
-    </permissions>
+    <requiresLogin/>
     <dependencies>
         <dependency path="snprc_scheduler/gen/app/app.css"/>
     </dependencies>


### PR DESCRIPTION
#### Rationale
`<permissions>` element is deprecated and soon to be removed