### PR TITLE
TAC updates for new ERP system changes and misc bug fix

### DIFF
--- a/snprc_ehr/resources/domain-templates/ehr.template.xml
+++ b/snprc_ehr/resources/domain-templates/ehr.template.xml
@@ -22,6 +22,14 @@
                     <dat:rangeURI>string</dat:rangeURI>
                     <dat:scale>2</dat:scale>
                 </dat:column>
+                <dat:column columnName="cost_account">
+                    <dat:columnTitle>Cost Account</dat:columnTitle>
+                    <dat:rangeURI>string</dat:rangeURI>
+                </dat:column>
+                <dat:column columnName="speedkey">
+                    <dat:columnTitle>Speedkey</dat:columnTitle>
+                    <dat:rangeURI>string</dat:rangeURI>
+                </dat:column>
             </dat:columns>
         </table>
     </template>

--- a/snprc_ehr/resources/queries/ehr/project/.qview.xml
+++ b/snprc_ehr/resources/queries/ehr/project/.qview.xml
@@ -5,9 +5,10 @@
         <column name="speedkey"/>
         <column name="cost_account"/>
         <column name="protocol"/>
-        <column name="inves"/>
+        <column name="research"/>
         <column name="startdate"/>
         <column name="enddate"/>
+        <column name="displayName"/>
     </columns>
     <sorts>
         <sort column="startdate" descending="true" />

--- a/snprc_ehr/resources/queries/ehr/project/.qview.xml
+++ b/snprc_ehr/resources/queries/ehr/project/.qview.xml
@@ -1,0 +1,15 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" label="Projects">
+    <columns>
+        <column name="project"/>
+        <column name="account"/>
+        <column name="speedkey"/>
+        <column name="cost_account"/>
+        <column name="protocol"/>
+        <column name="inves"/>
+        <column name="startdate"/>
+        <column name="enddate"/>
+    </columns>
+    <sorts>
+        <sort column="startdate" descending="true" />
+    </sorts>
+</customView>

--- a/snprc_ehr/resources/queries/study/BrowseDataSets.sql
+++ b/snprc_ehr/resources/queries/study/BrowseDataSets.sql
@@ -68,3 +68,5 @@ UNION
 select 'snprc_ehr' as schema, 'ClinPath' as CategoryId,'Urinalysis Results' as Label, 'HL7UrinalysisPivot' as Name,  true as ShowByDefault, true as isAnimal
 UNION
 select 'ehr' as schema, 'Colony Management' as CategoryId,'Kinship' as Label, 'kinship' as Name,  true as ShowByDefault, true as isAnimal
+UNION
+select 'ehr' as schema, 'Colony Management' as CategoryId,'Project' as Label, 'project' as Name,  true as ShowByDefault, false as isAnimal

--- a/snprc_ehr/resources/queries/study/demographicsParentStatus.query.xml
+++ b/snprc_ehr/resources/queries/study/demographicsParentStatus.query.xml
@@ -9,11 +9,7 @@
                     </column>
                     <column columnName="Parent_id">
                         <columnTitle>Parent Id</columnTitle>
-                        <fk>
-                            <fkDbSchema>study</fkDbSchema>
-                            <fkTable>animal</fkTable>
-                            <fkColumnName>id</fkColumnName>
-                        </fk>
+                        <url>ehr/participantView.view?participantId=${Parent_id}</url>
                     </column>
                     <column columnName="calculated_status">
                         <columnTitle>Status</columnTitle>

--- a/snprc_ehr/resources/source_queries/create_v_charge_account.sql
+++ b/snprc_ehr/resources/source_queries/create_v_charge_account.sql
@@ -30,7 +30,9 @@ ALTER VIEW [labkey_etl].[v_charge_account] AS
   SELECT
     ca.charge_id                     AS project,
 	CASE WHEN vcs.charge_id IS NULL THEN 'True' ELSE 'False' END AS research,
-    ca.cost_account                  AS account,
+    ca.cost_account                  AS cost_account,
+    ca.account_id                    AS account,
+    pca.speedkey                     AS speedkey,
     ca.working_iacuc                 AS protocol,
 	coalesce(right(ca.working_iacuc, 2), vcs.arc_species_code) as species,
     ca.start_date                    AS startdate,
@@ -46,6 +48,7 @@ ALTER VIEW [labkey_etl].[v_charge_account] AS
   FROM dbo.charge_account AS ca
     LEFT OUTER JOIN dbo.TAC_COLUMNS AS tc ON tc.object_id = ca.object_id
 	LEFT OUTER JOIN dbo.valid_charge_by_species AS vcs ON ca.charge_id = vcs.charge_id
+    LEFT OUTER JOIN dbo.prd_cost_account AS pca on pca.account_id = ca.account_id
 
 
 GO


### PR DESCRIPTION
- Added new "template-based" columns to the ehr.project table to accommodate speedkeys. The cost_account data in the account column was moved to the new cost_account column, and the account_id data is now placed in the account field. Speedkey is in the speedkey column.
- updated the source view to supply the new column data
- added default view for ehr.project table
- added the ehr.project table to browse all datasets
- updated the query metadata in demographicsParentStatus.query.xml to fix Issue 339: Incorrect links on parents


