### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/snprc_ehr/resources/views/ehrAdmin.view.xml
+++ b/snprc_ehr/resources/views/ehrAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Administration">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/snprc_ehr/resources/views/enterData.view.xml
+++ b/snprc_ehr/resources/views/enterData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Enter Data" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="snprc_ehr/panel/EnterDataPanel.js"/>

--- a/snprc_ehr/resources/views/sndEventsWidgetWebpart.view.xml
+++ b/snprc_ehr/resources/views/sndEventsWidgetWebpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="SND Events Widget">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/SndEventsWidgetWebpart"/>
     </dependencies>

--- a/snprc_r24/resources/views/welcome.view.xml
+++ b/snprc_r24/resources/views/welcome.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="R24 ETL Module">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.