### PR TITLE
CSP fixes

### DIFF
--- a/snprc_scheduler/src/client/styles/css/Accordion.style.css
+++ b/snprc_scheduler/src/client/styles/css/Accordion.style.css
@@ -1,7 +1,10 @@
-
+/*
+These CDNs are pulling in older versions of bootstrap css than what is being used in package.json.
+TODO: Use consistent version of bootstrap throughout app.
+ */
 @import url("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css");
 @import url("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css");
-@import url("https://npmcdn.com/react-bootstrap-table/dist/react-bootstrap-table-all.min.css");
+@import url("~react-bootstrap-table/dist/react-bootstrap-table-all.min.css");
 
 .scheduler-bs-accordion {
     margin-left: 17px;

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
@@ -89,8 +89,8 @@ public class SNPRC_schedulerModule extends DefaultModule
 
         // There are two versions of bootstrap in the main app for this module so the css for bootstrap 3.3.7 is brought in via CDN instead of NPM.
         // Register the external CDN sources for CSP filters.
-        ContentSecurityPolicyFilter.registerAllowedSources(Directive.Style, "bs_3_3_7_style", "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css", "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css");
-        ContentSecurityPolicyFilter.registerAllowedSources(Directive.Font, "bs_3_3_7_font", "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/fonts/");
+        ContentSecurityPolicyFilter.registerAllowedSources(Directive.Style, "bs_style", "https://maxcdn.bootstrapcdn.com/bootstrap/");
+        ContentSecurityPolicyFilter.registerAllowedSources(Directive.Font, "bs_font", "https://maxcdn.bootstrapcdn.com/bootstrap/");
     }
 
     @Override

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
@@ -11,6 +11,7 @@ import org.labkey.api.module.ModuleContext;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.resource.Resource;
+import org.labkey.api.security.Directive;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.snprc_scheduler.SNPRC_schedulerService;
@@ -19,6 +20,7 @@ import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.view.WebPartView;
+import org.labkey.filters.ContentSecurityPolicyFilter;
 import org.labkey.snprc_scheduler.security.SNPRC_schedulerAdminRole;
 import org.labkey.snprc_scheduler.security.SNPRC_schedulerEditorsRole;
 import org.labkey.snprc_scheduler.security.SNPRC_schedulerReadersRole;
@@ -84,6 +86,11 @@ public class SNPRC_schedulerModule extends DefaultModule
         RoleManager.registerRole(new SNPRC_schedulerEditorsRole(), false);
         RoleManager.registerRole(new SNPRC_schedulerReviewersRole(), false);
         RoleManager.registerRole(new SNPRC_schedulerAdminRole(), false);
+
+        // There are two versions of bootstrap in the main app for this module so the css for bootstrap 3.3.7 is brought in via CDN instead of NPM.
+        // Register the external CDN sources for CSP filters.
+        ContentSecurityPolicyFilter.registerAllowedSources(Directive.Style, "bs_3_3_7_style", "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css", "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css");
+        ContentSecurityPolicyFilter.registerAllowedSources(Directive.Font, "bs_3_3_7_font", "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/fonts/");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
CSP fixes for snprc scheduler

#### Changes
* Update react-bootstrap table to pull from node_modules instead of CDN
* Register BS 3.3.7 css files as allowed sources for CSP.
