### PR TITLE
Remove unnecessary HttpView.currentView() casts in JSPs

### DIFF
--- a/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeScheduleImport.jsp
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeScheduleImport.jsp
@@ -30,7 +30,7 @@
     }
 %>
 <%
-    JspView<FeeScheduleImportForm> me = (JspView<FeeScheduleImportForm>) HttpView.currentView();
+    JspView<FeeScheduleImportForm> me = HttpView.currentView();
     FeeScheduleImportForm bean = me.getModelBean();
     String importFormId = "FeeScheduleImportForm";
 %>


### PR DESCRIPTION
#### Rationale
Simple search and replace to clear warnings about unnecessary cast