### PR TITLE
Fix "wide index" error when importing reference study

### DIFF
--- a/snprc_ehr/test/sampledata/study/referenceStudy/study/datasets/datasets_metadata.xml
+++ b/snprc_ehr/test/sampledata/study/referenceStudy/study/datasets/datasets_metadata.xml
@@ -1617,6 +1617,7 @@
             </column>
             <column columnName="species">
                 <datatype>varchar</datatype>
+                <scale>100</scale>
                 <nullable>false</nullable>
                 <columnTitle>Species code (3 char)</columnTitle>
             </column>


### PR DESCRIPTION
#### Rationale
Default varchar scale is 4,000 characters, which is now too large to index on SQL Server. `Demographics.Species` is actually a 3-character code, so specify an explicit scale.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6633