### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/snprc_ehr/src/org/labkey/snprc_ehr/SNPRCBeanFactory.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/SNPRCBeanFactory.java
@@ -42,8 +42,8 @@ import java.util.Map;
 public class SNPRCBeanFactory<K> extends BeanObjectFactory<K>
 {
 
-    private static Logger _log = LogManager.getLogger(BeanObjectFactory.class);
-    private Class<K> _class;
+    private static final Logger _log = LogManager.getLogger(BeanObjectFactory.class);
+    private final Class<K> _class;
 
 
     public SNPRCBeanFactory(Class<K> clss)
@@ -55,9 +55,6 @@ public class SNPRCBeanFactory<K> extends BeanObjectFactory<K>
     /**
      * Maps property fooBar to key foo_bar, in preparation for CRUD operations
      *
-     * @param bean
-     * @param m
-     * @return
      */
     @Override
     public
@@ -128,7 +125,7 @@ public class SNPRCBeanFactory<K> extends BeanObjectFactory<K>
             }
             catch (IllegalAccessException | InvocationTargetException x)
             {
-                throw new UnexpectedException(x);
+                throw UnexpectedException.wrap(x);
             }
             catch (IllegalArgumentException x)
             {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRController.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRController.java
@@ -126,7 +126,7 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SSRSConfigAction extends FormViewAction<SSRSConfigForm>
+    public static class SSRSConfigAction extends FormViewAction<SSRSConfigForm>
     {
         @Override
         public void validateCommand(SSRSConfigForm target, Errors errors)
@@ -174,7 +174,7 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(ManageLookupTablesPermission.class)
-    public class EditLookupTablesAction extends SimpleViewAction
+    public static class EditLookupTablesAction extends SimpleViewAction<Object>
     {
 
         @Override
@@ -192,7 +192,7 @@ public class SNPRC_EHRController extends SpringActionController
 
 
     @RequiresPermission(UpdatePermission.class)
-    public class UpdateQueryAction extends SimpleViewAction<QueryForm>
+    public static class UpdateQueryAction extends SimpleViewAction<QueryForm>
     {
         private QueryForm _form;
 
@@ -265,7 +265,7 @@ public class SNPRC_EHRController extends SpringActionController
 
     // http://localhost:8080/labkey/snprc_ehr/snprc/getNextAnimalId
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class getNextAnimalIdAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class getNextAnimalIdAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public ApiResponse execute(SimpleApiJsonForm simpleApiJsonForm, BindException errors)
@@ -302,7 +302,7 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(SNPRCColonyAdminPermission.class)
-    public class BirthReportAction extends SimpleRedirectAction
+    public static class BirthReportAction extends SimpleRedirectAction<Object>
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -312,7 +312,7 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(SNPRCColonyAdminPermission.class)
-    public class SsrsReportsAction extends SimpleRedirectAction
+    public static class SsrsReportsAction extends SimpleRedirectAction<Object>
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -322,7 +322,7 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class IdChipReaderAction extends SimpleRedirectAction
+    public static class IdChipReaderAction extends SimpleRedirectAction
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -332,7 +332,7 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class SndEventViewAction extends SimpleRedirectAction
+    public static class SndEventViewAction extends SimpleRedirectAction<Object>
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -342,7 +342,7 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(SNPRCColonyAdminPermission.class)
-    public class NewAnimalWizardAction extends SimpleRedirectAction
+    public static class NewAnimalWizardAction extends SimpleRedirectAction<Object>
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -355,13 +355,13 @@ public class SNPRC_EHRController extends SpringActionController
      * Get all New Animals
      */
     @RequiresPermission(SNPRCColonyAdminPermission.class)
-    public class GetNewAnimalDataAction extends ReadOnlyApiAction<NewAnimalData>
+    public static class GetNewAnimalDataAction extends ReadOnlyApiAction<NewAnimalData>
     {
         @Override
         public ApiResponse execute(NewAnimalData o, BindException errors)
         {
 
-            Map<String, Object> props = new HashMap<String, Object>();
+            Map<String, Object> props = new HashMap<>();
 
 
             SimpleFilter filter = new SimpleFilter();
@@ -387,7 +387,7 @@ public class SNPRC_EHRController extends SpringActionController
      * Update/Add new animal
      */
     @RequiresPermission(SNPRCColonyAdminPermission.class)
-    public class UpdateAnimalDataAction extends MutatingApiAction<NewAnimalData>
+    public static class UpdateAnimalDataAction extends MutatingApiAction<NewAnimalData>
     {
         @Override
         public void validateForm(NewAnimalData newAnimalData, Errors errors)
@@ -480,12 +480,12 @@ public class SNPRC_EHRController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class RemoveCategoryAction extends MutatingApiAction<AnimalGroupCategory>
+    public static class RemoveCategoryAction extends MutatingApiAction<AnimalGroupCategory>
     {
         @Override
         public ApiResponse execute(AnimalGroupCategory animalGroupCategory, BindException errors)
         {
-            Map<String, Object> props = new HashMap<String, Object>();
+            Map<String, Object> props = new HashMap<>();
             try
             {
                 UserSchema us = new SNPRC_EHRUserSchema(getUser(), getContainer());
@@ -504,7 +504,7 @@ public class SNPRC_EHRController extends SpringActionController
                     categoriesFilter.addCondition(FieldKey.fromString("category_code"), animalGroupCategory.getCategoryCode(), CompareType.EQUAL);
                     Map<String, Object> animalGroupsCategory = new TableSelector(categoriesTable, categoriesFilter, null).getObject(Map.class);
 
-                    List<Map<String, Object>> keys = new ArrayList<Map<String, Object>>();
+                    List<Map<String, Object>> keys = new ArrayList<>();
 
                     Map<String, Object> idMap = new HashMap<>();
                     idMap.put("category_code", animalGroupsCategory.get("category_code"));

--- a/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalGroupsController.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalGroupsController.java
@@ -95,7 +95,7 @@ public class AnimalGroupsController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class GroupCategoriesAction extends SimpleViewAction<AnimalGroupCategory>
+    public static class GroupCategoriesAction extends SimpleViewAction<AnimalGroupCategory>
     {
         @Override
         public void addNavTrail(NavTree root)
@@ -114,13 +114,13 @@ public class AnimalGroupsController extends SpringActionController
      * Get all defined categories
      */
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class GetCategoriesAction extends ReadOnlyApiAction<AnimalGroupCategory>
+    public static class GetCategoriesAction extends ReadOnlyApiAction<AnimalGroupCategory>
     {
         @Override
         public ApiResponse execute(AnimalGroupCategory o, BindException errors)
         {
 
-            Map<String, Object> props = new HashMap<String, Object>();
+            Map<String, Object> props = new HashMap<>();
 
             Sort sort = SortFilterHelper.getSort(o.getSort(), true);
 
@@ -149,7 +149,7 @@ public class AnimalGroupsController extends SpringActionController
      * Update/Add category
      */
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class UpdateCategoriesAction extends MutatingApiAction<AnimalGroupCategory>
+    public static class UpdateCategoriesAction extends MutatingApiAction<AnimalGroupCategory>
     {
         @Override
         public ApiResponse execute(AnimalGroupCategory o, BindException errors)
@@ -225,12 +225,12 @@ public class AnimalGroupsController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class RemoveCategoryAction extends MutatingApiAction<AnimalGroupCategory>
+    public static class RemoveCategoryAction extends MutatingApiAction<AnimalGroupCategory>
     {
         @Override
         public ApiResponse execute(AnimalGroupCategory animalGroupCategory, BindException errors)
         {
-                Map<String, Object> props = new HashMap<String, Object>();
+                Map<String, Object> props = new HashMap<>();
             try
             {
                 UserSchema us = new SNPRC_EHRUserSchema(getUser(), getContainer());
@@ -249,7 +249,7 @@ public class AnimalGroupsController extends SpringActionController
                     categoriesFilter.addCondition(FieldKey.fromString("category_code"), animalGroupCategory.getCategoryCode(), CompareType.EQUAL);
                     Map<String, Object> animalGroupsCategory = new TableSelector(categoriesTable, categoriesFilter, null).getObject(Map.class);
 
-                    List<Map<String, Object>> keys = new ArrayList<Map<String, Object>>();
+                    List<Map<String, Object>> keys = new ArrayList<>();
 
                     Map<String, Object> idMap = new HashMap<>();
                     idMap.put("category_code", animalGroupsCategory.get("category_code"));
@@ -289,13 +289,13 @@ public class AnimalGroupsController extends SpringActionController
      * Get all defined species, needed when editing categories
      */
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class GetSpeciesAction extends ReadOnlyApiAction<AnimalSpecies>
+    public static class GetSpeciesAction extends ReadOnlyApiAction<AnimalSpecies>
     {
         @Override
         public ApiResponse execute(AnimalSpecies o, BindException errors)
         {
             List<JSONObject> jsonRows = new ArrayList<>();
-            Map<String, Object> props = new HashMap<String, Object>();
+            Map<String, Object> props = new HashMap<>();
 
             try
             {
@@ -334,12 +334,12 @@ public class AnimalGroupsController extends SpringActionController
      * Given a category, get all its groups
      */
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class GetGroupsByCategoryAction extends ReadOnlyApiAction<AnimalGroup>
+    public static class GetGroupsByCategoryAction extends ReadOnlyApiAction<AnimalGroup>
     {
         @Override
         public ApiResponse execute(AnimalGroup animalGroup, BindException errors)
         {
-            Map<String, Object> props = new HashMap<String, Object>();
+            Map<String, Object> props = new HashMap<>();
             UserSchema us = new SNPRC_EHRUserSchema(getUser(), getContainer());
 
             ArrayList<AnimalGroup> rows = new TableSelector(us.getTable("animal_groups", null, true, false),
@@ -359,7 +359,7 @@ public class AnimalGroupsController extends SpringActionController
      * Given a group, load all animals that are assigned to it
      */
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class GetAnimalsByGroupAction extends ReadOnlyApiAction<GroupMember>
+    public static class GetAnimalsByGroupAction extends ReadOnlyApiAction<GroupMember>
     {
         @Override
         public ApiResponse execute(GroupMember groupMember, BindException errors)
@@ -385,7 +385,7 @@ public class AnimalGroupsController extends SpringActionController
                 animals.add(member.toJSON());
             }
 
-            Map<String, Object> props = new HashMap<String, Object>();
+            Map<String, Object> props = new HashMap<>();
             props.put("animals", animals);
             props.put("success", true);
             return new ApiSimpleResponse(props);
@@ -396,7 +396,7 @@ public class AnimalGroupsController extends SpringActionController
      * Get Animals by name (animal id) - defined to present a list of valid animals to the user
      */
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class GetAnimalsByNameAction extends ReadOnlyApiAction<GroupMember>
+    public static class GetAnimalsByNameAction extends ReadOnlyApiAction<GroupMember>
     {
         @Override
         public ApiResponse execute(GroupMember groupMember, BindException errors)
@@ -425,7 +425,7 @@ public class AnimalGroupsController extends SpringActionController
      * validation of the data takes place in the animal_groups.js trigger script
      */
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class UpdateGroupsAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class UpdateGroupsAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public ApiResponse execute(SimpleApiJsonForm simpleApiJsonForm, BindException errors)
@@ -506,9 +506,6 @@ public class AnimalGroupsController extends SpringActionController
         /**
          * Get a group code to be assigned to a new group
          *
-         * @param categoryCode
-         * @param ignoreCategory - if true, this will return the next code regardless of the category the group belongs to
-         * @return
          */
         private Integer getNextGroupCode(int categoryCode, boolean ignoreCategory)
         {
@@ -524,7 +521,6 @@ public class AnimalGroupsController extends SpringActionController
         /**
          * Get a group code to be assigned to a new group
          *
-         * @param categoryCode
          * @return next code to be used for insert
          */
         private Integer getNextGroupCode(int categoryCode)
@@ -567,7 +563,7 @@ public class AnimalGroupsController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class DeleteGroupsAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class DeleteGroupsAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public ApiResponse execute(SimpleApiJsonForm simpleApiJsonForm, BindException errors)
@@ -637,7 +633,7 @@ public class AnimalGroupsController extends SpringActionController
      * Assigns animals to a group using an instance of  {@link AnimalsGroupAssignor}
      */
     @RequiresPermission(ManageGroupMembersPermission.class)
-    public class UpdateGroupMembersAction extends MutatingApiAction<GroupMember>
+    public static class UpdateGroupMembersAction extends MutatingApiAction<GroupMember>
     {
         @Override
         public ApiResponse execute(GroupMember groupMember, BindException errors)
@@ -655,7 +651,7 @@ public class AnimalGroupsController extends SpringActionController
 
             AnimalsGroupAssignor animalsGroupAssignor = new AnimalsGroupAssignor(this.getViewContext(), groupMember.getGroupid());
 
-            List<GroupMember> groupMembers = new ArrayList<GroupMember>();
+            List<GroupMember> groupMembers = new ArrayList<>();
             for (String animal : groupMember.getId().split("\n"))
             {
                 GroupMember animalForm = new GroupMember();
@@ -687,7 +683,7 @@ public class AnimalGroupsController extends SpringActionController
     }
 
     @RequiresPermission(ManageGroupMembersPermission.class)
-    public class DeleteGroupMembersAction extends MutatingApiAction<GroupMember>
+    public static class DeleteGroupMembersAction extends MutatingApiAction<GroupMember>
     {
         @Override
         public ApiResponse execute(GroupMember groupMember, BindException errors)
@@ -707,7 +703,7 @@ public class AnimalGroupsController extends SpringActionController
             filter.addCondition(FieldKey.fromString("date"), groupMember.getDate(), CompareType.EQUAL);
             TableSelector tableSelector = new TableSelector(table, filter, null);
 
-            List<Map<String, Object>> keys = new ArrayList<Map<String, Object>>();
+            List<Map<String, Object>> keys = new ArrayList<>();
             List<GroupMember> members = tableSelector.getArrayList(GroupMember.class);
             for (GroupMember member : members)
             {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalsHierarchyController.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalsHierarchyController.java
@@ -26,7 +26,6 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.ehr.dataentry.DataEntryForm;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -45,6 +44,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,16 +80,13 @@ public class AnimalsHierarchyController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetViewAction extends SimpleViewAction<ViewByForm>
+    public static class GetViewAction extends SimpleViewAction<ViewByForm>
     {
 
         @Override
         public ModelAndView getView(ViewByForm form, BindException errors)
         {
-
-            JspView<DataEntryForm> view = new JspView("/org/labkey/snprc_ehr/views/AnimalsHierarchy.jsp", this);
-            String viewBy = form.getViewBy();
-            if (viewBy == null) viewBy = "locations";
+            JspView<?> view = new JspView<>("/org/labkey/snprc_ehr/views/AnimalsHierarchy.jsp");
             view.setTitle("Animal Tree View Navigation");
             view.setHidePageTitle(true);
             view.setFrame(WebPartView.FrameType.PORTAL);
@@ -123,7 +120,7 @@ public class AnimalsHierarchyController extends SpringActionController
                     jsonRootLocations.add(node.toJSON());
                 }
 
-                Map props = new HashMap();
+                Map<String, Object> props = new HashMap<>();
 
 
                 props.put("nodes", jsonRootLocations);
@@ -151,7 +148,7 @@ public class AnimalsHierarchyController extends SpringActionController
                 jsonRootLocations.add(animal.toJSON());
             }
 
-            Map props = new HashMap();
+            Map<String, Object> props = new HashMap<>();
 
 
             props.put("nodes", jsonRootLocations);
@@ -203,12 +200,12 @@ public class AnimalsHierarchyController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetAnimals extends ReadOnlyApiAction<AnimalsBy>
+    public static class GetAnimals extends ReadOnlyApiAction<AnimalsBy>
     {
         @Override
         public Object execute(AnimalsBy animalsBy, BindException errors)
         {
-            List<Animal> animals = new ArrayList<Animal>();
+            List<Animal> animals = new ArrayList<>();
             Node node = new Node();
             switch (animalsBy.getBy().toLowerCase())
             {
@@ -266,7 +263,7 @@ public class AnimalsHierarchyController extends SpringActionController
                 jsonRootLocations.add(animal.toJSON());
             }
 
-            Map props = new HashMap();
+            Map<String, Object> props = new HashMap<>();
 
 
             props.put("animals", jsonRootLocations);
@@ -295,7 +292,7 @@ public class AnimalsHierarchyController extends SpringActionController
                 jsonLocationsPath.add(node.toJSON());
             }
 
-            Map props = new HashMap();
+            Map<String, Object> props = new HashMap<>();
 
 
             props.put("path", jsonLocationsPath);
@@ -309,26 +306,21 @@ public class AnimalsHierarchyController extends SpringActionController
 
     private HierarchyService getHierarchyService(String viewBy)
     {
-        HierarchyService hierarchyService;
         if (viewBy == null)
         {
             return new LocationHierarchyServiceImpl(this.getViewContext());
         }
-        switch (viewBy)
+        return switch (viewBy)
         {
-            case "locations":
-                return new LocationHierarchyServiceImpl(this.getViewContext());
-            case "groups":
-                return new GroupsHierarchyServiceImpl(this.getViewContext());
-            case "protocols":
-                return new ProtocolHierarchyServiceImpl(this.getViewContext());
-            default:
-                return new GroupsHierarchyServiceImpl(this.getViewContext());
-        }
+            case "locations" -> new LocationHierarchyServiceImpl(this.getViewContext());
+            case "groups" -> new GroupsHierarchyServiceImpl(this.getViewContext());
+            case "protocols" -> new ProtocolHierarchyServiceImpl(this.getViewContext());
+            default -> new GroupsHierarchyServiceImpl(this.getViewContext());
+        };
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetReportsAction extends ReadOnlyApiAction<Object>
+    public static class GetReportsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors)
@@ -344,11 +336,11 @@ public class AnimalsHierarchyController extends SpringActionController
             sort.appendSortColumn(FieldKey.fromString("sort_order"), Sort.SortDirection.ASC, false);
 
 
-            List<Map> reports = new TableSelector(reportsTable, filter, sort).getArrayList(Map.class);
+            Collection<Map<String, Object>> reports = new TableSelector(reportsTable, filter, sort).getMapCollection();
 
             JSONObject reportsJson = new JSONObject();
 
-            for (Map m : reports)
+            for (var m : reports)
             {
                 JSONObject reportObject = new JSONObject();
 
@@ -361,7 +353,7 @@ public class AnimalsHierarchyController extends SpringActionController
 
             }
 
-            Map props = new HashMap();
+            Map<String, Object> props = new HashMap<>();
             props.put("reports", reportsJson);
             return new ApiSimpleResponse(props);
         }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/controllers/FeeScheduleController.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/controllers/FeeScheduleController.java
@@ -95,7 +95,7 @@ public class FeeScheduleController extends SpringActionController
      * Landing page for a Fee Schedule Import
      */
     @RequiresPermission(AdminPermission.class)
-    public class FeeScheduleImportAction extends FormViewAction<FeeScheduleImportForm>
+    public static class FeeScheduleImportAction extends FormViewAction<FeeScheduleImportForm>
     {
         private String _navTrail = "Import Fee Schedule";
         private File _fsFile;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/ClinicalObservationsFormSection.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/ClinicalObservationsFormSection.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public class ClinicalObservationsFormSection extends SimpleFormSection
 {
-    private boolean _allowAdd = true;
+    private boolean _allowAdd;
 
     public ClinicalObservationsFormSection()
     {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/ClinpathFormSection.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/ClinpathFormSection.java
@@ -36,7 +36,7 @@ public class ClinpathFormSection extends SimpleGridPanel
     @Override
     public List<String> getTbarButtons()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         defaultButtons.add("COPYFROMCLINPATHRUNS");
         defaultButtons.addAll(super.getTbarButtons());
 

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/ClinpathRunsFormSection.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/ClinpathRunsFormSection.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class ClinpathRunsFormSection extends SimpleGridPanel
 {
-    boolean _isRequest = false;
+    boolean _isRequest;
 
     public ClinpathRunsFormSection(boolean isRequest)
     {
@@ -44,7 +44,7 @@ public class ClinpathRunsFormSection extends SimpleGridPanel
     @Override
     public List<String> getTbarButtons()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         defaultButtons.addAll(super.getTbarButtons());
 
         if (!_isRequest)

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/EncounterChildFormSection.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/EncounterChildFormSection.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
  */
 public class EncounterChildFormSection extends SimpleGridPanel
 {
-    private boolean _allowAddDefaults;
+    private final boolean _allowAddDefaults;
 
     public EncounterChildFormSection(String schemaName, String queryName, String label, boolean allowAddDefaults)
     {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/LabworkFormSection.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/LabworkFormSection.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 public class LabworkFormSection extends SimpleGridPanel
 {
-    private boolean _allowPanelEdit = false;
+    private boolean _allowPanelEdit;
 
     public LabworkFormSection(String schemaName, String queryName, String label)
     {
@@ -54,7 +54,7 @@ public class LabworkFormSection extends SimpleGridPanel
     @Override
     public List<String> getTbarButtons()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         defaultButtons.add("COPYFROMCLINPATHRUNS");
         defaultButtons.addAll(super.getTbarButtons());
         defaultButtons.remove("ADDANIMALS");

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/SNPRCTaskForm.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/SNPRCTaskForm.java
@@ -36,7 +36,7 @@ public class SNPRCTaskForm extends TaskForm
     @Override
     protected List<String> getButtonConfigs()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         defaultButtons.add("SAVEDRAFT");
         defaultButtons.add("SUBMIT");
         //defaultButtons.add("REVIEW");

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/SingleSurgeryFormType.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/SingleSurgeryFormType.java
@@ -25,7 +25,6 @@ import org.labkey.api.ehr.dataentry.NonStoreFormSection;
 import org.labkey.api.ehr.dataentry.TaskFormSection;
 import org.labkey.api.ehr.security.EHRSurgeryEntryPermission;
 import org.labkey.api.module.Module;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.PrincipalType;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.UserPrincipal;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/SurgeryFormType.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/SurgeryFormType.java
@@ -25,7 +25,6 @@ import org.labkey.api.ehr.dataentry.NonStoreFormSection;
 import org.labkey.api.ehr.dataentry.TaskFormSection;
 import org.labkey.api.ehr.security.EHRSurgeryEntryPermission;
 import org.labkey.api.module.Module;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.PrincipalType;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.UserPrincipal;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/UnsaveableTask.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/dataentry/dataentry/UnsaveableTask.java
@@ -46,7 +46,7 @@ abstract public class UnsaveableTask extends TaskForm
     @Override
     protected List<String> getButtonConfigs()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         defaultButtons.add("SUBMIT");
 
         return defaultButtons;
@@ -55,7 +55,7 @@ abstract public class UnsaveableTask extends TaskForm
     @Override
     protected List<String> getMoreActionButtonConfigs()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         defaultButtons.add("VALIDATEALL");
 
         defaultButtons.add("FORCESUBMIT");

--- a/snprc_ehr/src/org/labkey/snprc_ehr/demographics/ActiveAssignmentsDemographicsProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/demographics/ActiveAssignmentsDemographicsProvider.java
@@ -40,7 +40,7 @@ public class ActiveAssignmentsDemographicsProvider extends AbstractListDemograph
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/snprc_ehr/src/org/labkey/snprc_ehr/demographics/ActiveCasesDemographicsProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/demographics/ActiveCasesDemographicsProvider.java
@@ -15,28 +15,15 @@
  */
 package org.labkey.snprc_ehr.demographics;
 
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.Results;
-import org.labkey.api.data.ResultsImpl;
-import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.demographics.AbstractListDemographicsProvider;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.security.User;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -53,7 +40,7 @@ public class ActiveCasesDemographicsProvider extends AbstractListDemographicsPro
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("objectid"));
         keys.add(FieldKey.fromString("Id"));

--- a/snprc_ehr/src/org/labkey/snprc_ehr/demographics/ActiveFlagsDemographicsProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/demographics/ActiveFlagsDemographicsProvider.java
@@ -16,28 +16,14 @@
 package org.labkey.snprc_ehr.demographics;
 
 
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.Results;
-import org.labkey.api.data.ResultsImpl;
-import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.Sort;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.demographics.AbstractListDemographicsProvider;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.security.User;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -54,7 +40,7 @@ public class ActiveFlagsDemographicsProvider extends AbstractListDemographicsPro
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/snprc_ehr/src/org/labkey/snprc_ehr/demographics/BirthDemographicsProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/demographics/BirthDemographicsProvider.java
@@ -41,7 +41,7 @@ public class BirthDemographicsProvider extends AbstractListDemographicsProvider
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/snprc_ehr/src/org/labkey/snprc_ehr/demographics/CurrentAccountsDemographicsProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/demographics/CurrentAccountsDemographicsProvider.java
@@ -15,28 +15,15 @@
  */
 package org.labkey.snprc_ehr.demographics;
 
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.Results;
-import org.labkey.api.data.ResultsImpl;
-import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.demographics.AbstractListDemographicsProvider;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.security.User;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**

--- a/snprc_ehr/src/org/labkey/snprc_ehr/demographics/CurrentDietDemographicsProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/demographics/CurrentDietDemographicsProvider.java
@@ -22,7 +22,6 @@ import org.labkey.api.module.Module;
 import org.labkey.api.query.FieldKey;
 
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -42,7 +41,7 @@ public class CurrentDietDemographicsProvider extends AbstractListDemographicsPro
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("code"));

--- a/snprc_ehr/src/org/labkey/snprc_ehr/enums/AssignmentFailureReason.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/enums/AssignmentFailureReason.java
@@ -34,7 +34,7 @@ public enum AssignmentFailureReason
     INVALID_START_OR_END_DATE("End Date must be greater than Start Date."),
     END_DATE_REQUIRED("Group member must have an end date when the group has an end date.");
 
-    private String reason;
+    private final String reason;
 
     AssignmentFailureReason(String reason)
     {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/helpers/CustomizerQueryProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/helpers/CustomizerQueryProvider.java
@@ -42,14 +42,6 @@ public class CustomizerQueryProvider
      * Checks if the passed table exists, the primary key and id columns,
      * and builds table with calculated fields from SQL query. Returns false if any checks fail and
      * true if all checks pass and the table is successfully built
-     * @param tableInfo
-     * @param columnName
-     * @param dateColumnName
-     * @param queryString
-     * @param ehrSchema
-     * @param calculatedColumns
-     * @param isRemovingDefaultCustomizerColumns
-     * @return
      */
     public AbstractTableInfo getCalculatedColumnsTable(AbstractTableInfo tableInfo, String columnName, String dateColumnName,
                                        String queryString, UserSchema ehrSchema,
@@ -85,8 +77,6 @@ public class CustomizerQueryProvider
 
     /**
      * Obtain the column info for the primary key of a given table
-     * @param tableInfo
-     * @return
      */
     private ColumnInfo getPrimaryKeyColumn(TableInfo tableInfo) {
         List<ColumnInfo> primaryKeys = tableInfo.getPkColumns();
@@ -95,13 +85,6 @@ public class CustomizerQueryProvider
 
     /**
      * Returns a new query info object to be used for calculating a column's info
-     * @param tableInfo
-     * @param primaryKeyColumn
-     * @param idColumn
-     * @param ehrSchema
-     * @param label
-     * @param calculatedColumns
-     * @return
      */
     private CalculatedColumnQueryInfo getQueryInfo(AbstractTableInfo tableInfo, ColumnInfo primaryKeyColumn,
                                                    ColumnInfo idColumn, UserSchema ehrSchema,
@@ -120,9 +103,6 @@ public class CustomizerQueryProvider
 
     /**
      * Returns a wrapped column object from a given query and it's information
-     * @param queryInfo
-     * @param queryString
-     * @return
      */
     private WrappedColumn getWrappedCalculatedColumn(CalculatedColumnQueryInfo queryInfo, String queryString) {
         WrappedColumn column = new WrappedColumn(queryInfo.getPrimaryKeyColumn(), CaseUtils.toCamelCase(queryInfo.getLabel(),
@@ -139,10 +119,6 @@ public class CustomizerQueryProvider
     /**
      * Maps values from the query object's data to the variable names within the SQL query string
      * (formatted for the Apache Commons Lang StrSubstitor where ${variableName} maps to variableName)
-     * @param queryString
-     * @param queryInfo
-     * @param dateColumnName
-     * @return
      */
     private String mapQueryStringValues(String queryString, CalculatedColumnQueryInfo queryInfo, String dateColumnName) {
         Map<String, String> queryByValues = new HashMap<>();

--- a/snprc_ehr/src/org/labkey/snprc_ehr/helpers/SortFilterHelper.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/helpers/SortFilterHelper.java
@@ -37,7 +37,7 @@ public class SortFilterHelper
     {
         Sort sort = new Sort();
 
-        if (sortBy == null || sortBy.equals(""))
+        if (sortBy == null || sortBy.isEmpty())
         {
             return sort;
         }
@@ -65,13 +65,12 @@ public class SortFilterHelper
 
     /**
      * @param filterBy json string of the form [{"property":"columnName","value":"foo"}]
-     * @return
      */
     public static SimpleFilter getFilter(String filterBy)
     {
         SimpleFilter filter = new SimpleFilter();
 
-        if (filterBy == null || filterBy.equals(""))
+        if (filterBy == null || filterBy.isEmpty())
         {
             return filter;
         }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/history/DefaultObservationsDataSource.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/history/DefaultObservationsDataSource.java
@@ -20,8 +20,6 @@ import org.labkey.api.data.Results;
 import org.labkey.api.ehr.history.AbstractDataSource;
 import org.labkey.api.module.Module;
 
-import java.sql.SQLException;
-
 /**
  * Created by Marty on 12/8/2016.
  */

--- a/snprc_ehr/src/org/labkey/snprc_ehr/history/DefaultTreatmentOrdersDataSource.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/history/DefaultTreatmentOrdersDataSource.java
@@ -37,22 +37,21 @@ public class DefaultTreatmentOrdersDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, null, "code"));
-        sb.append(safeAppend(rs, "Category", "category"));
-        sb.append(safeAppendDateAndTime(rs, "Start Date", "date"));
-        sb.append(safeAppend(rs, "Amount", "amount"));
-        sb.append(safeAppend(rs, "Units", "amount_units"));
-        sb.append(safeAppend(rs, "Route", "route"));
-        sb.append(safeAppend(rs, "Frequency", "frequency"));
-        sb.append(safeAppend(rs, "Duration", "duration"));
-        sb.append(safeAppend(rs, "Reason", "reason"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
-        sb.append(safeAppend(rs, "Description", "description"));
-        sb.append(safeAppendDateAndTime(rs, "End Date", "enddate"));
+        String sb = safeAppend(rs, null, "code") +
+                safeAppend(rs, "Category", "category") +
+                safeAppendDateAndTime(rs, "Start Date", "date") +
+                safeAppend(rs, "Amount", "amount") +
+                safeAppend(rs, "Units", "amount_units") +
+                safeAppend(rs, "Route", "route") +
+                safeAppend(rs, "Frequency", "frequency") +
+                safeAppend(rs, "Duration", "duration") +
+                safeAppend(rs, "Reason", "reason") +
+                safeAppend(rs, "Remark", "remark") +
+                safeAppend(rs, "Description", "description") +
+                safeAppendDateAndTime(rs, "End Date", "enddate");
 
-        return sb.toString();
+        return sb;
     }
     protected String safeAppendDateAndTime(Results rs, String label, String field) throws SQLException {
         FieldKey fk = FieldKey.fromString(field);

--- a/snprc_ehr/src/org/labkey/snprc_ehr/history/LabworkDataSource.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/history/LabworkDataSource.java
@@ -155,7 +155,7 @@ public class LabworkDataSource extends AbstractDataSource
         TableSelector ts = new TableSelector(ti, PageFlowUtil.set("parentid", "flag", "value"), filter, null);
         final Map<String, List<String>> map = new HashMap<>();
 
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException

--- a/snprc_ehr/src/org/labkey/snprc_ehr/history/LabworkType.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/history/LabworkType.java
@@ -153,7 +153,7 @@ public class LabworkType extends DefaultLabworkType
             _tests = new CaseInsensitiveHashMap<>();
 
             TableSelector ts = new TableSelector(ti, PageFlowUtil.set(_sortCol, _testCol), new SimpleFilter(FieldKey.fromString(_serviceIdField), _serviceId), null);
-            ts.forEach(new Selector.ForEachBlock<>()
+            ts.forEach(new Selector.ForEachBlock<ResultSet>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -170,7 +170,7 @@ public class LabworkType extends DefaultLabworkType
     protected Map<String, List<String>> getRows(TableSelector ts, final Collection<ColumnInfo> cols, final boolean redacted)
     {
         final Map<String, Map<Integer, List<String>>> rows = new HashMap<>();
-        ts.forEach(new Selector.ForEachBlock<>()
+        ts.forEach(new Selector.ForEachBlock<ResultSet>()
                    {
                        boolean forceRefresh = true;
 

--- a/snprc_ehr/src/org/labkey/snprc_ehr/history/LabworkType.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/history/LabworkType.java
@@ -63,8 +63,8 @@ public class LabworkType extends DefaultLabworkType
 
     private static String _serviceId;
     private static String _serviceType;
-    private String _testCol = "TestId";
-    private String _sortCol = "sortOrder";
+    private final String _testCol = "TestId";
+    private final String _sortCol = "sortOrder";
     private Map<String, Integer> _tests = null;
 
     public LabworkType(Module module)
@@ -153,7 +153,7 @@ public class LabworkType extends DefaultLabworkType
             _tests = new CaseInsensitiveHashMap<>();
 
             TableSelector ts = new TableSelector(ti, PageFlowUtil.set(_sortCol, _testCol), new SimpleFilter(FieldKey.fromString(_serviceIdField), _serviceId), null);
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -170,7 +170,7 @@ public class LabworkType extends DefaultLabworkType
     protected Map<String, List<String>> getRows(TableSelector ts, final Collection<ColumnInfo> cols, final boolean redacted)
     {
         final Map<String, Map<Integer, List<String>>> rows = new HashMap<>();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
                    {
                        boolean forceRefresh = true;
 

--- a/snprc_ehr/src/org/labkey/snprc_ehr/history/OffspringDataSource.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/history/OffspringDataSource.java
@@ -36,13 +36,12 @@ public class OffspringDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Offspring ID", "Offspring"));
-        sb.append(safeAppend(rs, "Sex", "sex"));
-        sb.append(safeAppend(rs, "Sire", "sire"));
-        sb.append(safeAppend(rs, "Dam", "dam"));
+        String sb = safeAppend(rs, "Offspring ID", "Offspring") +
+                safeAppend(rs, "Sex", "sex") +
+                safeAppend(rs, "Sire", "sire") +
+                safeAppend(rs, "Dam", "dam");
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/model/CalculatedColumnQueryInfo.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/model/CalculatedColumnQueryInfo.java
@@ -8,7 +8,6 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.query.UserSchema;
 import org.labkey.snprc_ehr.model.CalculatedColumn;
 
-import java.util.List;
 import java.util.Set;
 
 /**

--- a/snprc_ehr/src/org/labkey/snprc_ehr/notification/AbstractSSRSNotification.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/notification/AbstractSSRSNotification.java
@@ -203,13 +203,13 @@ public abstract class AbstractSSRSNotification implements Notification
                 }
                 catch (MessagingException e)
                 {
-                    throw new UnexpectedException(e);
+                    throw UnexpectedException.wrap(e);
                 }
             }
         }
         catch (URISyntaxException | IOException e)
         {
-            throw new UnexpectedException(e);
+            throw UnexpectedException.wrap(e);
         }
     }
 

--- a/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeScheduleExcelParser.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeScheduleExcelParser.java
@@ -55,8 +55,8 @@ public class FeeScheduleExcelParser
     private boolean _parsed;
     private String _feeScheduleSheetName; // = "Capped Fee Schedule"; //"Actual Cost Fee Schedule";
     private final int _numberOfSkipHeaderRows = 2;
-    private Map<Integer, FeeScheduleDataRow> _feeScheduleMap = new LinkedHashMap<>();
-    private Map<Integer, String> _columnNameMap = new LinkedHashMap<>();
+    private final Map<Integer, FeeScheduleDataRow> _feeScheduleMap = new LinkedHashMap<>();
+    private final Map<Integer, String> _columnNameMap = new LinkedHashMap<>();
     private String _yearPublished;
     private Container _container;
     private User _user;
@@ -125,7 +125,7 @@ public class FeeScheduleExcelParser
                     }
                 }
             }
-            if (tabPageNames.size() == 0)
+            if (tabPageNames.isEmpty())
             {
                 throw new PipelineJobException("No Fee Schedule found in workbook.");
             }
@@ -156,8 +156,8 @@ public class FeeScheduleExcelParser
         // tab page selected in jsp
         int rowIdx;
         String value;
-        Double doubleValue;
-        boolean hasData = false;
+        double doubleValue;
+        boolean hasData;
         Workbook workbook = null;
         Sheet sheet;
 
@@ -230,7 +230,7 @@ public class FeeScheduleExcelParser
                 if (row != null)
                 {
                     FeeScheduleDataRow dataRow = new FeeScheduleDataRow();
-                    Map<String, Double> costValueMap = new LinkedHashMap<String, Double>();
+                    Map<String, Double> costValueMap = new LinkedHashMap<>();
 
                     for (int col = 0; col < _columnNameMap.size(); col++) //row.getLastCellNum(); col++)
                     {
@@ -259,7 +259,7 @@ public class FeeScheduleExcelParser
                             if (ExcelFactory.isCellNumeric(cell))
                             {
                                 doubleValue = cell.getNumericCellValue();
-                                dataRow.setActivityId(doubleValue.intValue());
+                                dataRow.setActivityId((int) doubleValue);
                             }
                             else
                             {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeSchedulePipelineJob.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeSchedulePipelineJob.java
@@ -22,12 +22,10 @@ import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.Path;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.vfs.FileLike;
-import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 

--- a/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeSchedulePipelineProvider.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/pipeline/FeeSchedulePipelineProvider.java
@@ -36,7 +36,7 @@ import java.io.FileFilter;
     {
         public static final String NAME = "FeeSchedulePipeline";
 
-        FileFilter _fileMaskFilter = null;
+        FileFilter _fileMaskFilter;
 
         public FeeSchedulePipelineProvider(Module owningModule)
         {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/query/CalculatedColumnForeignKey.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/query/CalculatedColumnForeignKey.java
@@ -4,9 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.BaseColumnInfo;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.ldk.table.AbstractTableCustomizer;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryDefinition;
@@ -20,24 +18,20 @@ import org.labkey.snprc_ehr.model.CalculatedColumn;
 import org.labkey.snprc_ehr.model.CalculatedColumnQueryInfo;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class CalculatedColumnForeignKey extends LookupForeignKey
 {
     private static final Logger _log = LogManager.getLogger(CalculatedColumnForeignKey.class);
 
     /* Query info object */
-    private CalculatedColumnQueryInfo _queryInfo;
+    private final CalculatedColumnQueryInfo _queryInfo;
 
     /* SQL query to be used to calculate column values */
-    private String _queryString;
+    private final String _queryString;
 
     /**
      * Constructor
-     * @param queryInfo
-     * @param queryString
      */
     public CalculatedColumnForeignKey(CalculatedColumnQueryInfo queryInfo, String queryString) {
         _queryInfo = queryInfo;
@@ -46,7 +40,6 @@ public class CalculatedColumnForeignKey extends LookupForeignKey
 
     /**
      * Returns a table that contains the new foreign key columns that were calculated via SQL query
-     * @return
      */
     @Override
     public TableInfo getLookupTableInfo() {
@@ -63,7 +56,7 @@ public class CalculatedColumnForeignKey extends LookupForeignKey
 
         List<QueryException> errors = new ArrayList<>();
         TableInfo lookupTable = queryDefinition.getTable(errors, true);
-        if (errors.size() > 0) {
+        if (!errors.isEmpty()) {
             _log.error("Error creating lookup table for: " + schemaName + "." + queryName + " in container: " + targetSchema.getContainer().getPath());
             errors.forEach(error -> _log.error(error.getMessage(), error));
             return null;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/query/SNPRC_EHRTriggerHelper.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/query/SNPRC_EHRTriggerHelper.java
@@ -296,7 +296,7 @@ public class SNPRC_EHRTriggerHelper
             QueryUpdateService qus = flagsTable.getUpdateService();
 
             TableSelector ts = new TableSelector(flagsTable, PageFlowUtil.set("lsid", "Id", "enddate"), filter, null);
-            ts.forEach(new Selector.ForEachBlock<>()
+            ts.forEach(new Selector.ForEachBlock<ResultSet>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException

--- a/snprc_ehr/src/org/labkey/snprc_ehr/query/SNPRC_EHRTriggerHelper.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/query/SNPRC_EHRTriggerHelper.java
@@ -55,9 +55,9 @@ import java.util.Set;
 public class SNPRC_EHRTriggerHelper
 {
     private static final Logger _log = LogManager.getLogger(SNPRC_EHRTriggerHelper.class);
-    private Container _container = null;
-    private User _user = null;
-    private Map<String, TableInfo> _cachedTables = new HashMap<>();
+    private final Container _container;
+    private final User _user;
+    private final Map<String, TableInfo> _cachedTables = new HashMap<>();
 
 
 
@@ -235,7 +235,7 @@ public class SNPRC_EHRTriggerHelper
 
     public Map<String, Object> getExtraContext()
     {
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         map.put("quickValidation", true);
         map.put("generatedByServer", true);
 
@@ -296,7 +296,7 @@ public class SNPRC_EHRTriggerHelper
             QueryUpdateService qus = flagsTable.getUpdateService();
 
             TableSelector ts = new TableSelector(flagsTable, PageFlowUtil.set("lsid", "Id", "enddate"), filter, null);
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -313,22 +313,14 @@ public class SNPRC_EHRTriggerHelper
 
             try
             {
-                if (rows.size() > 0)
+                if (!rows.isEmpty())
                 {
                     Map<String, Object> extraContext = getExtraContext();
                     extraContext.put("skipAnnounceChangedParticipants", true);
                     qus.updateRows(getUser(), flagsTable.getUserSchema().getContainer(), rows, oldKeys, null, extraContext);
                 }
             }
-            catch (InvalidKeyException e)
-            {
-                throw new RuntimeException(e);
-            }
-            catch (BatchValidationException e)
-            {
-                throw new RuntimeException(e);
-            }
-            catch (QueryUpdateServiceException e)
+            catch (InvalidKeyException | QueryUpdateServiceException | BatchValidationException e)
             {
                 throw new RuntimeException(e);
             }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/services/AnimalsGroupAssignor.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/services/AnimalsGroupAssignor.java
@@ -56,8 +56,8 @@ import java.util.Map;
 public class AnimalsGroupAssignor
 {
     ViewContext viewContext;
-    private AnimalGroup group;
-    private AnimalGroupCategory category;
+    private final AnimalGroup group;
+    private final AnimalGroupCategory category;
 
 
 
@@ -201,7 +201,7 @@ public class AnimalsGroupAssignor
                 selector = new SqlSelector(dbStudySchema, sql);
 
                 if (selector.exists())
-                    throw new ValidationException(AssignmentFailureReason.ALREADY_IN_GROUP.toString() + ": " + groupMember.getParticipantid());
+                    throw new ValidationException(AssignmentFailureReason.ALREADY_IN_GROUP + ": " + groupMember.getParticipantid());
             }
 
             // if category groups are mutually exclusive, then we need to make sure animal
@@ -232,7 +232,7 @@ public class AnimalsGroupAssignor
 
                 selector = new SqlSelector(dbStudySchema, sql);
                 if (selector.exists())
-                    throw new ValidationException(AssignmentFailureReason.ALREADY_IN_CATEGORY.toString() + ": " + groupMember.getParticipantid());
+                    throw new ValidationException(AssignmentFailureReason.ALREADY_IN_CATEGORY + ": " + groupMember.getParticipantid());
 
             }
             // if future dates are not allowed, then we need to make sure a future date is not being entered
@@ -272,7 +272,7 @@ public class AnimalsGroupAssignor
 
                 if (!animal_species.equalsIgnoreCase(category_speciesCode))
                 {
-                    throw new ValidationException(AssignmentFailureReason.NOT_APPLICABLE_SPECIES.toString() + " Id: " + groupMember.getParticipantid() + "  Species: " + animal_species);
+                    throw new ValidationException(AssignmentFailureReason.NOT_APPLICABLE_SPECIES + " Id: " + groupMember.getParticipantid() + "  Species: " + animal_species);
                 }
 
             }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/services/GroupsHierarchyServiceImpl.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/services/GroupsHierarchyServiceImpl.java
@@ -42,7 +42,7 @@ import java.util.Map;
  */
 public class GroupsHierarchyServiceImpl implements HierarchyService
 {
-    private ViewContext viewContext;
+    private final ViewContext viewContext;
 
     public GroupsHierarchyServiceImpl(ViewContext viewContext)
     {
@@ -52,7 +52,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
     @Override
     public List<Node> getRootNodes()
     {
-        List<Node> categoryNodes = new ArrayList<Node>();
+        List<Node> categoryNodes = new ArrayList<>();
         SimpleFilter displayable = new SimpleFilter();
         displayable.addCondition(FieldKey.fromString("displayable"), "Y", CompareType.EQUAL);
 
@@ -72,7 +72,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
     @Override
     public List<Node> getSubNodes(Node node)
     {
-        List<Node> categoryGroupNodes = new ArrayList<Node>();
+        List<Node> categoryGroupNodes = new ArrayList<>();
         try
         {
             Integer categoryCode = Integer.parseInt(node.getNode().replace("CATEGORY-", ""));
@@ -109,7 +109,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
     {
         if (!node.getNode().contains("GROUP"))
         {
-            return new ArrayList<Animal>();
+            return new ArrayList<>();
         }
         String[] stringParts = node.getNode().split("-");
         try
@@ -150,7 +150,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
             TableInfo demographicsTable = schema.getTable("demographics");
             SimpleFilter animalFilter = new SimpleFilter();
 
-            List<String> animalIds = new ArrayList<String>();
+            List<String> animalIds = new ArrayList<>();
             for (Animal animal : animals)
             {
                 animalIds.add(animal.getText());
@@ -165,7 +165,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
                 oneAnimalDemographicsMap.put("status", a.get("calculated_status"));
                 demographicsMap.put((String) a.get("id"), oneAnimalDemographicsMap);
             }
-            List<Animal> notAliveAnimals = new ArrayList<Animal>();
+            List<Animal> notAliveAnimals = new ArrayList<>();
             for (Animal animal : animals)
             {
                 if (demographicsMap.containsKey(animal.getText()))
@@ -184,7 +184,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
         }
         catch (Exception ex)
         {
-            return new ArrayList<Animal>();
+            return new ArrayList<>();
         }
     }
 
@@ -208,7 +208,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
             return null;
         }
         Node rootNode = new Node();
-        Map<String, Object> props = new HashMap<String, Object>();
+        Map<String, Object> props = new HashMap<>();
 
         UserSchema us = new SNPRC_EHRUserSchema(this.viewContext.getUser(), this.viewContext.getContainer());
         AnimalGroup group = new TableSelector(us.getTable("animal_groups"), new SimpleFilter().addCondition(FieldKey.fromString("code"),
@@ -231,7 +231,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
 
         Animal animalRecord = new TableSelector(demographicsTable, demographicsFilter, null).getObject(Animal.class);
 
-        List<Node> locationsPath = new ArrayList<Node>();
+        List<Node> locationsPath = new ArrayList<>();
 
         AnimalNodePath animalNodePath = new AnimalNodePath();
         animalNodePath.setAnimalId(animal.getParticipantid());

--- a/snprc_ehr/src/org/labkey/snprc_ehr/services/GroupsHierarchyServiceImpl.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/services/GroupsHierarchyServiceImpl.java
@@ -109,7 +109,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
     {
         if (!node.getNode().contains("GROUP"))
         {
-            return new ArrayList<>();
+            return new ArrayList<Animal>();
         }
         String[] stringParts = node.getNode().split("-");
         try
@@ -184,7 +184,7 @@ public class GroupsHierarchyServiceImpl implements HierarchyService
         }
         catch (Exception ex)
         {
-            return new ArrayList<>();
+            return new ArrayList<Animal>();
         }
     }
 

--- a/snprc_ehr/src/org/labkey/snprc_ehr/services/LocationHierarchyServiceImpl.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/services/LocationHierarchyServiceImpl.java
@@ -47,7 +47,7 @@ import java.util.Map;
  */
 public class LocationHierarchyServiceImpl implements HierarchyService
 {
-    private ViewContext viewContext;
+    private final ViewContext viewContext;
 
     public LocationHierarchyServiceImpl(ViewContext viewContext)
     {
@@ -73,7 +73,7 @@ public class LocationHierarchyServiceImpl implements HierarchyService
         List<Map> maps = new TableSelector(housingTable, currentHousingRecordsFilter, sort).getArrayList(Map.class);
 
         List<Node> rootNodes = new ArrayList<>();
-        List<Node> alreadySeenNodes = new ArrayList<Node>();
+        List<Node> alreadySeenNodes = new ArrayList<>();
 
         for (Map map : maps)
         {
@@ -184,7 +184,7 @@ public class LocationHierarchyServiceImpl implements HierarchyService
         TableInfo demographicsTable = userSchema.getTable("demographics");
         SimpleFilter filter = new SimpleFilter();
 
-        List<String> animalIds = new ArrayList<String>();
+        List<String> animalIds = new ArrayList<>();
         for (Animal animal : animals)
         {
             animalIds.add(animal.getId());
@@ -200,7 +200,7 @@ public class LocationHierarchyServiceImpl implements HierarchyService
             oneAnimalDemographicsMap.put("status", a.get("calculated_status"));
             demographicsMap.put((String) a.get("id"), oneAnimalDemographicsMap);
         }
-        List<Animal> notAliveAnimals = new ArrayList<Animal>();
+        List<Animal> notAliveAnimals = new ArrayList<>();
         for (Animal animal : animals)
         {
             if (demographicsMap.containsKey(animal.getId()))
@@ -221,7 +221,6 @@ public class LocationHierarchyServiceImpl implements HierarchyService
 
 
     /**
-     * @param node
      * @return true if node is a root node, false otherwise
      */
     @Override
@@ -274,7 +273,7 @@ public class LocationHierarchyServiceImpl implements HierarchyService
         AnimalNodePath animalNodePath = new AnimalNodePath();
         animalNodePath.setAnimalId(animal.getParticipantid());
 
-        List<Node> locationsPath = new ArrayList<Node>();
+        List<Node> locationsPath = new ArrayList<>();
         animalNodePath.setLocations(locationsPath);
 
         if (map == null)

--- a/snprc_ehr/src/org/labkey/snprc_ehr/services/ProtocolHierarchyServiceImpl.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/services/ProtocolHierarchyServiceImpl.java
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 public class ProtocolHierarchyServiceImpl implements HierarchyService
 {
-    private ViewContext viewContext;
+    private final ViewContext viewContext;
 
     public ProtocolHierarchyServiceImpl(ViewContext viewContext)
     {
@@ -60,7 +60,7 @@ public class ProtocolHierarchyServiceImpl implements HierarchyService
         List<Map> maps = new TableSelector(assignmentTable, currentAssignmentsRecordsFilter, sort).getArrayList(Map.class);
 
         List<Node> rootNodes = new ArrayList<>();
-        List<Node> alreadySeenNodes = new ArrayList<Node>();
+        List<Node> alreadySeenNodes = new ArrayList<>();
 
         for (Map map : maps)
         {
@@ -107,7 +107,7 @@ public class ProtocolHierarchyServiceImpl implements HierarchyService
     @Override
     public List<Node> getSubNodes(Node node)
     {
-        return new ArrayList<Node>();
+        return new ArrayList<>();
     }
 
     @Override
@@ -129,8 +129,8 @@ public class ProtocolHierarchyServiceImpl implements HierarchyService
         sort.insertSortColumn(FieldKey.fromString("participantid"), Sort.SortDirection.ASC);
 
         List<Animal> animals = new TableSelector(assignmentTable, currentAssignmentRecordsFilter, sort).getArrayList(Animal.class);
-        List<Animal> distinctAnimals = new ArrayList<Animal>();
-        List<String> animalIds = new ArrayList<String>();
+        List<Animal> distinctAnimals = new ArrayList<>();
+        List<String> animalIds = new ArrayList<>();
 
         for (Animal animal : animals)
         {
@@ -156,7 +156,7 @@ public class ProtocolHierarchyServiceImpl implements HierarchyService
             oneAnimalDemographicsMap.put("status", a.get("calculated_status"));
             demographicsMap.put((String) a.get("id"), oneAnimalDemographicsMap);
         }
-        List<Animal> notAliveAnimals = new ArrayList<Animal>();
+        List<Animal> notAliveAnimals = new ArrayList<>();
         for (Animal animal : distinctAnimals)
         {
             if (demographicsMap.containsKey(animal.getText()))
@@ -206,7 +206,7 @@ public class ProtocolHierarchyServiceImpl implements HierarchyService
         Animal animalDemographicsRecord = new TableSelector(demographicsTable, demographicsFilter, null).getObject(Animal.class);
 
 
-        List<Node> locationsPath = new ArrayList<Node>();
+        List<Node> locationsPath = new ArrayList<>();
 
         AnimalNodePath animalNodePath = new AnimalNodePath();
         animalNodePath.setAnimalId(animal.getParticipantid());

--- a/snprc_ehr/src/org/labkey/snprc_ehr/services/ProtocolHierarchyServiceImpl.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/services/ProtocolHierarchyServiceImpl.java
@@ -107,7 +107,7 @@ public class ProtocolHierarchyServiceImpl implements HierarchyService
     @Override
     public List<Node> getSubNodes(Node node)
     {
-        return new ArrayList<>();
+        return new ArrayList<Node>();
     }
 
     @Override

--- a/snprc_ehr/src/org/labkey/snprc_ehr/services/SNPRC_EHRValidator.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/services/SNPRC_EHRValidator.java
@@ -12,7 +12,6 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.snprc_ehr.domain.NewAnimalData;
 
-import java.util.Date;
 import java.util.Map;
 
 public class SNPRC_EHRValidator

--- a/snprc_ehr/src/org/labkey/snprc_ehr/snd/triggers/BloodDrawTrigger.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/snd/triggers/BloodDrawTrigger.java
@@ -141,7 +141,7 @@ public class BloodDrawTrigger implements EventTrigger
 
         // Currently this queries study.blood. This is still pending tying SND with SNPRC study queries
         TableInfo ti = TriggerHelper.getTableInfo(c, u,"study", "Blood Draws", errors);
-        if (ti == null || errors.size() > 0)
+        if (ti == null || !errors.isEmpty())
         {
             // if ti is null, there will be an error in errors
             return;
@@ -195,7 +195,7 @@ public class BloodDrawTrigger implements EventTrigger
     {
         TableInfo ti = TriggerHelper.getTableInfo(c, u,"snprc_ehr", "species", errors);
         Map<String, Object> speciesBlood = null;
-        if (errors.size() == 0 && ti != null)
+        if (errors.isEmpty() && ti != null)
         {
             // Cols to retrieve
             Set<String> cols = new HashSet<>();
@@ -269,7 +269,7 @@ public class BloodDrawTrigger implements EventTrigger
 
         List<ValidationException> errors = new ArrayList<>();
         Map<String, Object> bloodBySpecies = getBloodInfoForSpecies(c, u, species, errors);
-        if (errors.size() > 0)
+        if (!errors.isEmpty())
         {
             eventData.setException(event, errors.get(0));
             return;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/snd/triggers/FemaleOnlyTrigger.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/snd/triggers/FemaleOnlyTrigger.java
@@ -40,7 +40,7 @@ public class FemaleOnlyTrigger implements EventTrigger
         List<ValidationException> errors = new ArrayList<>();
         boolean genderMatches = TriggerHelper.verifyGender(c, triggerAction.getEvent().getSubjectId(), expectedGender, errors);
 
-        if (errors.size() > 0)
+        if (!errors.isEmpty())
         {
             event.setException(errors.get(0));
         }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/snd/triggers/MaleOnlyTrigger.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/snd/triggers/MaleOnlyTrigger.java
@@ -40,7 +40,7 @@ public class MaleOnlyTrigger implements EventTrigger
         List<ValidationException> errors = new ArrayList<>();
         boolean genderMatches = TriggerHelper.verifyGender(c, triggerAction.getEvent().getSubjectId(), expectedGender, errors);
 
-        if (errors.size() > 0)
+        if (!errors.isEmpty())
         {
             event.setException(errors.get(0));
         }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/steps/SuperPackageLoadTask.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/steps/SuperPackageLoadTask.java
@@ -62,7 +62,7 @@ public class SuperPackageLoadTask extends TaskRefTaskImpl
             TableSelector ts = new TableSelector(ti, filter, sort);
             List<SuperPackage> superPackages = ts.getArrayList(SuperPackage.class);
 
-            if (superPackages == null || superPackages.size() == 0)
+            if (superPackages == null || superPackages.isEmpty())
             {
                 job.getLogger().info("No new super packages found in " + SNPRC_EHRSchema.TABLE_SND_SUPER_PACKAGE_STAGING);
                 return;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAccountDisplayColumnFactory.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAccountDisplayColumnFactory.java
@@ -57,7 +57,7 @@ public class AnimalAccountDisplayColumnFactory implements DisplayColumnFactory
         return new AnimalAccountDisplayColumn(colInfo);
     }
 
-    public class AnimalAccountDisplayColumn extends DataColumn
+    public static class AnimalAccountDisplayColumn extends DataColumn
     {
 
         public AnimalAccountDisplayColumn(ColumnInfo col)
@@ -98,14 +98,13 @@ public class AnimalAccountDisplayColumnFactory implements DisplayColumnFactory
             ArrayList<String> errors = new ArrayList<>();
             SimpleDateFormat dateFormat = new SimpleDateFormat("MM-dd-yy");
 
-            StringBuilder sb = new StringBuilder();
-            sb.append("<table border=1 style='border-collapse: collapse; border: 1px'><colgroup><col width='110'><col width='110'><col width='130'></colgroup>");
-            //sb.append("<th>Account</th><th>Start Date</th><th>Group</th>");
-            sb.append("<tr><td>" + PageFlowUtil.filter(dataMap.get("account")) + "</td>" );
-            sb.append("<td>" + dateFormat.format(dataMap.get("date")) + "</td>");
-            sb.append("<td>" + PageFlowUtil.filter(dataMap.get("accountGroup")) + "</td></tr></table>");
+            String sb = "<table border=1 style='border-collapse: collapse; border: 1px'><colgroup><col width='110'><col width='110'><col width='130'></colgroup>" +
+                    //sb.append("<th>Account</th><th>Start Date</th><th>Group</th>");
+                    "<tr><td>" + PageFlowUtil.filter(dataMap.get("account")) + "</td>" +
+                    "<td>" + dateFormat.format(dataMap.get("date")) + "</td>" +
+                    "<td>" + PageFlowUtil.filter(dataMap.get("accountGroup")) + "</td></tr></table>";
 
-            String html = PageFlowUtil.validateHtml(sb.toString(), errors, false);
+            String html = PageFlowUtil.validateHtml(sb, errors, false);
             if (errors.isEmpty())
                 return HtmlString.unsafe(html);
             else
@@ -127,12 +126,11 @@ public class AnimalAccountDisplayColumnFactory implements DisplayColumnFactory
             ArrayList<String> errors = new ArrayList<>();
             SimpleDateFormat dateFormat = new SimpleDateFormat("MM-dd-yy");
 
-            StringBuilder sb = new StringBuilder();
-            sb.append("Account: " + dataMap.get("account") + "  " );
-            sb.append("Date: " + dateFormat.format(dataMap.get("date")) + "  ");
-            sb.append("Account Groups: " + dataMap.get("accountGroup"));
+            String sb = "Account: " + dataMap.get("account") + "  " +
+                    "Date: " + dateFormat.format(dataMap.get("date")) + "  " +
+                    "Account Groups: " + dataMap.get("accountGroup");
 
-            return sb.toString();
+            return sb;
         }
 
     }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAccountDisplayColumnFactory.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAccountDisplayColumnFactory.java
@@ -123,14 +123,11 @@ public class AnimalAccountDisplayColumnFactory implements DisplayColumnFactory
             if (dataMap.isEmpty())
                 return "";
 
-            ArrayList<String> errors = new ArrayList<>();
             SimpleDateFormat dateFormat = new SimpleDateFormat("MM-dd-yy");
 
-            String sb = "Account: " + dataMap.get("account") + "  " +
+            return "Account: " + dataMap.get("account") + "  " +
                     "Date: " + dateFormat.format(dataMap.get("date")) + "  " +
                     "Account Groups: " + dataMap.get("accountGroup");
-
-            return sb;
         }
 
     }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAssignmentDisplayColumnFactory.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAssignmentDisplayColumnFactory.java
@@ -63,13 +63,10 @@ public class AnimalAssignmentDisplayColumnFactory implements DisplayColumnFactor
 
     public static class AnimalAssignmentDisplayColumn extends DataColumn
     {
-        private final ColumnInfo col;
-
         public AnimalAssignmentDisplayColumn(ColumnInfo col)
         {
             super(col,false);
             setRequiresHtmlFiltering(false);
-            this.col = col;
         }
 
         private TableSelector getTs(RenderContext ctx)
@@ -126,7 +123,6 @@ public class AnimalAssignmentDisplayColumnFactory implements DisplayColumnFactor
                     String date = dateFormat.format(rs.getDate("date"));
                     String assignmentStatus = PageFlowUtil.filter(rs.getString("assignmentStatus"));
                     String remark = PageFlowUtil.filter(rs.getString("remark"));
-                    //remark = (remark == null) ? "" : remark;
                     sb.append("<tr><td>" + protocol + "</td><td>" + date + "</td><td>" + assignmentStatus + "</td>");
                     sb.append("<td>" + remark + "</td>" + "<td></tr>");
                 }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAssignmentDisplayColumnFactory.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/table/AnimalAssignmentDisplayColumnFactory.java
@@ -57,13 +57,13 @@ public class AnimalAssignmentDisplayColumnFactory implements DisplayColumnFactor
     @Override
     public DisplayColumn createRenderer(ColumnInfo colInfo)
     {
-        return new AnimalAssignmentDisplayColumnFactory.AnimalAssignmentDisplayColumn(colInfo);
+        return new AnimalAssignmentDisplayColumn(colInfo);
     }
 
 
-    public class AnimalAssignmentDisplayColumn extends DataColumn
+    public static class AnimalAssignmentDisplayColumn extends DataColumn
     {
-        private ColumnInfo col;
+        private final ColumnInfo col;
 
         public AnimalAssignmentDisplayColumn(ColumnInfo col)
         {
@@ -117,7 +117,7 @@ public class AnimalAssignmentDisplayColumnFactory implements DisplayColumnFactor
             sb.append("<table border=1 style='border-collapse: collapse;border: 3px'><colgroup><col width='80'><col width='110'><col width='40'><col width='150'></colgroup>");
             //sb.append("<th>Protocol</th><th>Date</th><th>Status</th><th>Comment</th>");
 
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -126,9 +126,9 @@ public class AnimalAssignmentDisplayColumnFactory implements DisplayColumnFactor
                     String date = dateFormat.format(rs.getDate("date"));
                     String assignmentStatus = PageFlowUtil.filter(rs.getString("assignmentStatus"));
                     String remark = PageFlowUtil.filter(rs.getString("remark"));
-                           //remark = (remark == null) ? "" : remark;
+                    //remark = (remark == null) ? "" : remark;
                     sb.append("<tr><td>" + protocol + "</td><td>" + date + "</td><td>" + assignmentStatus + "</td>");
-                    sb.append("<td>" + remark +  "</td>" + "<td></tr>");
+                    sb.append("<td>" + remark + "</td>" + "<td></tr>");
                 }
             });
             sb.append("</table>");
@@ -156,7 +156,7 @@ public class AnimalAssignmentDisplayColumnFactory implements DisplayColumnFactor
             SimpleDateFormat dateFormat = new SimpleDateFormat("MM-dd-yy");
 
             StringBuilder sb = new StringBuilder();
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException

--- a/snprc_ehr/src/org/labkey/snprc_ehr/table/EventNarrativeDisplayColumnFactory.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/table/EventNarrativeDisplayColumnFactory.java
@@ -12,10 +12,10 @@ public class EventNarrativeDisplayColumnFactory implements DisplayColumnFactory
     @Override
     public DisplayColumn createRenderer(ColumnInfo colInfo)
     {
-        return new EventNarrativeDisplayColumnFactory.EventNarrativeDisplayColumn(colInfo);
+        return new EventNarrativeDisplayColumn(colInfo);
     }
 
-    public class EventNarrativeDisplayColumn extends DataColumn
+    public static class EventNarrativeDisplayColumn extends DataColumn
     {
         public EventNarrativeDisplayColumn(ColumnInfo col)
         {

--- a/snprc_ehr/src/org/labkey/snprc_ehr/table/SNPRC_EHRCustomizer.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/table/SNPRC_EHRCustomizer.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.snprc_ehr.table;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -59,7 +58,7 @@ public class SNPRC_EHRCustomizer extends AbstractTableCustomizer
 {
     private static final Logger _log = LogHelper.getLogger(SNPRC_EHRCustomizer.class, "SNPRC_EHR Table Customizer Class");
 
-    private CustomizerQueryProvider _provider;
+    private final CustomizerQueryProvider _provider;
 
     private Set<CalculatedColumn> calculatedColumns;
 
@@ -170,7 +169,7 @@ public class SNPRC_EHRCustomizer extends AbstractTableCustomizer
         }
         if (matches(ti, "study", "housing"))
         {
-            customizeHousingTable((AbstractTableInfo) ti);
+            customizeHousingTable(ti);
         }
 //        if (matches(ti, "ehr", "project")) {
 //            customizeProjectTable((AbstractTableInfo) ti);
@@ -201,18 +200,16 @@ public class SNPRC_EHRCustomizer extends AbstractTableCustomizer
 
     /**
      * Performs table customizations for columns that are calculated by SQL queries
-     * @param tableInfo
      */
     public void doCalculatedCustomizations(AbstractTableInfo tableInfo) {
         if (tableInfo.getColumn(DATE_COLUMN) != null) {
-            addCalculatedColumns((AbstractTableInfo) tableInfo);
+            addCalculatedColumns(tableInfo);
         }
     }
 
 
     /**
      * Checks the user schema and whether the table is 'demographics' and performs the necessary column calculations
-     * @param table
      */
     private void addCalculatedColumns(AbstractTableInfo table)
     {
@@ -227,9 +224,6 @@ public class SNPRC_EHRCustomizer extends AbstractTableCustomizer
     /**
      * Checks the table and schema information and invokes provider method to build the table with the
      * IACUC Assignment Calculated columns
-     * @param ehrSchema
-     * @param tableInfo
-     * @param dateColumnName
      */
     private void appendAssignmentAtTimeColumn(UserSchema ehrSchema, AbstractTableInfo tableInfo, final String dateColumnName) {
 
@@ -249,9 +243,6 @@ public class SNPRC_EHRCustomizer extends AbstractTableCustomizer
     /**
      * Checks the table and schema information and invokes provider method to build the table with the
      * Age At Time calculated columns
-     * @param ehrSchema
-     * @param tableInfo
-     * @param dateColumnName
      */
     private void appendAgeAtTimeColumn(UserSchema ehrSchema, AbstractTableInfo tableInfo, String dateColumnName) {
 
@@ -277,8 +268,6 @@ public class SNPRC_EHRCustomizer extends AbstractTableCustomizer
 
     /**
      * Checks if the current table has a lookup value in the animal table
-     * @param tableInfo
-     * @return
      */
     private boolean hasAnimalLookup(AbstractTableInfo tableInfo) {
         var idCol = tableInfo.getMutableColumn(ID_COLUMN);
@@ -287,8 +276,6 @@ public class SNPRC_EHRCustomizer extends AbstractTableCustomizer
 
     /**
      * Checks if the current table is demographics
-     * @param tableInfo
-     * @return
      */
     private boolean isDemographicsTable(TableInfo tableInfo) {
         return tableInfo.getName().equalsIgnoreCase(DEMOGRAPHICS_TABLE) && tableInfo.getPublicSchemaName().equalsIgnoreCase(STUDY_SCHEMA);

--- a/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
+++ b/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
@@ -149,7 +149,7 @@ public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOn
     @BeforeClass
     public static void setupProject() throws Exception
     {
-        SNPRC_EHRTest initTest = (SNPRC_EHRTest) getCurrentTest();
+        SNPRC_EHRTest initTest = getCurrentTest();
 
         initTest.doSetup();
     }
@@ -304,22 +304,22 @@ public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOn
 
         // Valid accounts
         List<Map<String, Object>> accountRows = Arrays.asList(
-                new HashMap<String, Object>(Maps.of("account", "1000-100-10",
+                new HashMap<>(Maps.of("account", "1000-100-10",
                         "description", "Doe, 1111MM",
                         "accountStatus", "A",
                         "accountGroup", "Doe",
                         "date", DATE_FORMAT.format(DateUtils.addDays(new Date(), -20)))),
-                new HashMap<String, Object>(Maps.of("account", "2000-200-20",
+                new HashMap<>(Maps.of("account", "2000-200-20",
                         "description", "Smith, 2222PC",
                         "accountStatus", "A",
                         "accountGroup", "Smith 2222",
                         "date", DATE_FORMAT.format(DateUtils.addDays(new Date(), -15)))),
-                new HashMap<String, Object>(Maps.of("account", "3000-300-30",
+                new HashMap<>(Maps.of("account", "3000-300-30",
                         "description", "Yu, Reseach 1212",
                         "accountStatus", "A",
                         "accountGroup", "Undefined",
                         "date", DATE_FORMAT.format(DateUtils.addDays(new Date(), -2)))),
-                new HashMap<String, Object>(Maps.of("account", "4000-400-40",
+                new HashMap<>(Maps.of("account", "4000-400-40",
                         "description", "General clinical",
                         "accountStatus", "I",
                         "accountGroup", "Clinical",
@@ -609,7 +609,7 @@ public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOn
         //check count and links for one subject
         final WebElement overview = PortalHelper.Locators.webPart("Overview").waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
         DataRegionTable tbl = DataRegion(getDriver()).find(overview);
-        assertEquals(tbl.getDataRowCount(), 49);
+        assertEquals(49, tbl.getDataRowCount());
         assertElementPresent(Locator.linkWithText("TEST1020148"));
         assertElementPresent(Locator.linkWithText("Male"));
         assertElementPresent(Locator.linkWithText("Alive"));
@@ -902,12 +902,12 @@ public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOn
         historyPage.clickReportTab("Kinship");
 
         DataRegionTable tbl = historyPage.getActiveReportDataRegion();
-        assertEquals(tbl.getDataRowCount(), 20);
+        assertEquals(20, tbl.getDataRowCount());
 
         _ext4Helper.checkCheckbox(Locator.ehrCheckboxIdContaining("limitRawDataToSelection"));
 
         tbl = historyPage.getActiveReportDataRegion();
-        assertEquals(tbl.getDataRowCount(), 2);
+        assertEquals(2, tbl.getDataRowCount());
 
         String[] idCols = {"Id", "Id2", "Coefficient"};
         List<List<String>> rows = tbl.getRows(idCols);

--- a/snprc_r24/resources/transform/src/AbstractAssayValidator.java
+++ b/snprc_r24/resources/transform/src/AbstractAssayValidator.java
@@ -26,11 +26,11 @@ public abstract class AbstractAssayValidator
     private String _email;
     private String _password;
     private File _errorFile;
-    private Map<String, String> _runProperties = new HashMap<>();
-    private Map<String, String> _transformFile = new HashMap<>();
-    private List<String> _errors = new ArrayList<>();
+    private final Map<String, String> _runProperties = new HashMap<>();
+    private final Map<String, String> _transformFile = new HashMap<>();
+    private final List<String> _errors = new ArrayList<>();
     private String _host;
-    private  String ERROR_FILE = "c:\\temp\\Labkey\\error.txt";
+    private final String ERROR_FILE = "c:\\temp\\Labkey\\error.txt";
 
     public enum Props {
         assayId,                // the assay id from the run properties field

--- a/snprc_r24/resources/transform/src/MicrobiomeTransform.java
+++ b/snprc_r24/resources/transform/src/MicrobiomeTransform.java
@@ -25,14 +25,12 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.poi.ss.usermodel.DateUtil;
 
-import com.google.common.collect.*;
-
 public class MicrobiomeTransform extends AbstractAssayValidator
 {
     private File _errorFile;
-    private Map<String, String> _runProperties = new HashMap<>();
-    private Map<Integer, String> _colMap = new HashMap<>();
-    private Map<String, String> _dictionary = new HashMap<>();
+    private final Map<String, String> _runProperties = new HashMap<>();
+    private final Map<Integer, String> _colMap = new HashMap<>();
+    private final Map<String, String> _dictionary = new HashMap<>();
     private final int numHeaderCols = 4;
 
     public static void main(String[] args)
@@ -121,7 +119,7 @@ public class MicrobiomeTransform extends AbstractAssayValidator
                     }
                     else
                     {
-                        writeError("Encountered Invalid column header: " + getValue(cell) + " " + sb.toString(), "");
+                        writeError("Encountered Invalid column header: " + getValue(cell) + " " + sb, "");
                        //throw new IllegalArgumentException("Encountered Invalid column header: " + getValue(cell) + "\n");
                     }
 
@@ -146,7 +144,7 @@ public class MicrobiomeTransform extends AbstractAssayValidator
     // Can add more checking here
     private boolean isValid(String common)
     {
-        return !common.isEmpty() && common.trim().length() > 0;
+        return !common.isEmpty() && !common.trim().isEmpty();
     }
 
 
@@ -159,7 +157,7 @@ public class MicrobiomeTransform extends AbstractAssayValidator
         Cell cell;
 
         int i = 0;
-        Integer rowNum = 0;
+        int rowNum;
 
         for (Map.Entry<Integer, String> entry : _colMap.entrySet())
         {
@@ -179,7 +177,7 @@ public class MicrobiomeTransform extends AbstractAssayValidator
                     else
                     {
                         rowNum = row.getRowNum();
-                        writeError("Missing row identifyer informaion on row: " + rowNum.toString(), "");
+                        writeError("Missing row identifyer informaion on row: " + rowNum, "");
                     }
                 }
                 catch (IOException e)
@@ -258,7 +256,7 @@ public class MicrobiomeTransform extends AbstractAssayValidator
                             {
 
                                 sb.append(getColumns(nextRow));
-                                System.out.println(sb.toString());
+                                System.out.println(sb);
                                 first = false;
 
                             }
@@ -267,7 +265,7 @@ public class MicrobiomeTransform extends AbstractAssayValidator
                                 sb.append(processRow(nextRow));
                             }
 
-                            writer.print(sb.toString());
+                            writer.print(sb);
                         }
 
                     }

--- a/snprc_r24/src/org/labkey/snprc_r24/snprc_r24Controller.java
+++ b/snprc_r24/src/org/labkey/snprc_r24/snprc_r24Controller.java
@@ -36,12 +36,12 @@ public class snprc_r24Controller extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
-            return new JspView("/org/labkey/snprc_r24/view/hello.jsp");
+            return new JspView<>("/org/labkey/snprc_r24/view/hello.jsp");
         }
 
         @Override

--- a/snprc_r24/src/org/labkey/snprc_r24/snprc_r24Module.java
+++ b/snprc_r24/src/org/labkey/snprc_r24/snprc_r24Module.java
@@ -18,7 +18,6 @@ package org.labkey.snprc_r24;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerController.java
@@ -32,7 +32,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 
 import java.text.ParseException;
-import java.time.DateTimeException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -55,7 +54,7 @@ public class SNPRC_schedulerController extends SpringActionController
     //http://localhost:8080/labkey/snprc_scheduler/snprc/Begin.view?
     @RequiresPermission(SNPRC_schedulerReadersPermission.class)
     //@RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleRedirectAction
+    public static class BeginAction extends SimpleRedirectAction<Object>
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -66,7 +65,7 @@ public class SNPRC_schedulerController extends SpringActionController
 
     // http://localhost:8080/labkey/snprc_scheduler/snprc/getActiveTimelines.view?ProjectObjectId=55130483-F7DD-4366-8FA3-55ED58115482
     @RequiresPermission(SNPRC_schedulerReadersPermission.class)
-    public class getActiveTimelinesAction extends ReadOnlyApiAction<Timeline>
+    public static class getActiveTimelinesAction extends ReadOnlyApiAction<Timeline>
     {
         @Override
         public ApiResponse execute(Timeline timeline, BindException errors)
@@ -101,7 +100,7 @@ public class SNPRC_schedulerController extends SpringActionController
     // on the specified date.
 
     @RequiresPermission(SNPRC_schedulerReadersPermission.class)
-    public class getScheduledTimelinesForSpeciesAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    public static class getScheduledTimelinesForSpeciesAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
         @Override
         public ApiResponse execute(SimpleApiJsonForm form, BindException errors)
@@ -176,7 +175,7 @@ public class SNPRC_schedulerController extends SpringActionController
      */
 
     @RequiresPermission(SNPRC_schedulerReadersPermission.class)
-    public class getActiveProjectsAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    public static class getActiveProjectsAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
         @Override
         public ApiResponse execute(SimpleApiJsonForm simpleApiJsonForm, BindException errors)
@@ -250,7 +249,7 @@ public class SNPRC_schedulerController extends SpringActionController
 
                 List<Map<String, Object>> projects = SNDService.get().getActiveProjects(getContainer(), getUser(), filters, true, eventDate);
 
-                if (projects.size() > 0)
+                if (!projects.isEmpty())
                 {
                     //   SND returned the project table data, need to add Iacuc and CostAccount fields from ehr.project table
                     UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), "ehr");
@@ -297,7 +296,7 @@ public class SNPRC_schedulerController extends SpringActionController
 
     // http://localhost:8080/labkey/snprc_scheduler/snprc/updateTimeline.view?
     @RequiresPermission(SNPRC_schedulerEditorsPermission.class)
-    public class updateTimelineAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class updateTimelineAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public void validateForm(SimpleApiJsonForm form, Errors errors)

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerManager.java
@@ -315,7 +315,7 @@ public class SNPRC_schedulerManager
             {
                 Set<String> cols;
                 SimpleFilter filter;
-                Map<String, Object> row = new HashMap<>();
+                Map<String, Object> row;
                 List<Map<String, Object>> rows = new ArrayList<>();
 
 
@@ -356,7 +356,7 @@ public class SNPRC_schedulerManager
                     row.put(TimelineItem.TIMELINEITEM_TIMELINE_ITEM_ID, timelineItemId);
                     rows.add(row);
                 }
-                if (rows.size() > 0)
+                if (!rows.isEmpty())
                 {
                     qus.deleteRows(u, c, rows, null, null);
                 }
@@ -816,7 +816,7 @@ public class SNPRC_schedulerManager
                     timelineAnimalItem.setObjectId(new GUID().toString());
                     timelineAnimalItemRows.add(timelineAnimalItem.toMap(c));
 
-                    if (timelineAnimalItemRows.size() > 0 )
+                    if (!timelineAnimalItemRows.isEmpty())
                     {
                         List<Map<String, Object>> insertedRow = qus.insertRows(u, c, timelineAnimalItemRows, errors, null, null);
 

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerSequencer.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerSequencer.java
@@ -9,8 +9,8 @@ public enum SNPRC_schedulerSequencer
 {
     TIMELINEID ("org.labkey.snprc_scheduler.domain.Timeline", 100);
 
-    private String sequenceName;
-    private int minId;
+    private final String sequenceName;
+    private final int minId;
     SNPRC_schedulerSequencer(String name, int id)
     {
         sequenceName = name;

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerUserSchema.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerUserSchema.java
@@ -21,7 +21,7 @@ import org.labkey.snprc_scheduler.query.TimelineTable;
 public class SNPRC_schedulerUserSchema extends SimpleUserSchema
 {
 
-    private boolean _permissionCheck = true;
+    private final boolean _permissionCheck = true;
 
     public SNPRC_schedulerUserSchema(User user, Container container)
     {

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/Timeline.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/domains/Timeline.java
@@ -555,7 +555,7 @@ public class Timeline //extends Entity
         values.put(TIMELINE_PROTOCOL, getProtocol());
         values.put(TIMELINE_ANIMAL_ACCOUNT, getAnimalAccount());
 
-        if (getTimelineItems().size() > 0)
+        if (!getTimelineItems().isEmpty())
         {
             List<Map<String, Object>> listTimelineItems = new ArrayList<>();
             for (TimelineItem timelineItem : getTimelineItems())
@@ -564,7 +564,7 @@ public class Timeline //extends Entity
             }
             values.put(TIMELINE_TIMELINE_ITEMS, listTimelineItems);
         }
-        if (getTimelineProjectItems().size() > 0)
+        if (!getTimelineProjectItems().isEmpty())
         {
             List<Map<String, Object>> listTimelineProjectItems = new ArrayList<>();
             for (TimelineProjectItem timelineProjectItem : getTimelineProjectItems())
@@ -573,7 +573,7 @@ public class Timeline //extends Entity
             }
             values.put(TIMELINE_TIMELINE_PROJECT_ITEMS, listTimelineProjectItems);
         }
-        if (getTimelineAnimalItems().size() > 0)
+        if (!getTimelineAnimalItems().isEmpty())
         {
             List<Map<String, Object>> listTimelineAnimalItems = new ArrayList<>();
             for (TimelineAnimalJunction timelineAnimalItem : getTimelineAnimalItems())
@@ -582,7 +582,7 @@ public class Timeline //extends Entity
             }
             values.put(TIMELINE_ANIMAL_ITEMS, listTimelineAnimalItems);
         }
-        if (getStudyDayNotes().size() > 0)
+        if (!getStudyDayNotes().isEmpty())
         {
             List<Map<String, Object>> listStudyDayNotes = new ArrayList<>();
             for (StudyDayNotes studyDayNote : getStudyDayNotes())
@@ -636,7 +636,7 @@ public class Timeline //extends Entity
         json.put(TIMELINE_PROTOCOL, getProtocol());
         json.put(TIMELINE_ANIMAL_ACCOUNT, getAnimalAccount());
 
-        if (getTimelineItems().size() > 0)
+        if (!getTimelineItems().isEmpty())
         {
             JSONArray jsonTimelineItems = new JSONArray();
             for (TimelineItem timelineItem : getTimelineItems())
@@ -645,7 +645,7 @@ public class Timeline //extends Entity
             }
             json.put(TIMELINE_TIMELINE_ITEMS, jsonTimelineItems);
         }
-        if (getTimelineProjectItems().size() > 0)
+        if (!getTimelineProjectItems().isEmpty())
         {
             JSONArray jsonTimelineProjectItems = new JSONArray();
             for (TimelineProjectItem timelineProjectItem : getTimelineProjectItems())
@@ -654,7 +654,7 @@ public class Timeline //extends Entity
             }
             json.put(TIMELINE_TIMELINE_PROJECT_ITEMS, jsonTimelineProjectItems);
         }
-        if (getTimelineAnimalItems().size() > 0)
+        if (!getTimelineAnimalItems().isEmpty())
         {
             JSONArray jsonTimelineAnimalItems = new JSONArray();
             for (TimelineAnimalJunction timelineAnimalItem : getTimelineAnimalItems())
@@ -663,7 +663,7 @@ public class Timeline //extends Entity
             }
             json.put(TIMELINE_ANIMAL_ITEMS, jsonTimelineAnimalItems);
         }
-        if (getStudyDayNotes().size() > 0)
+        if (!getStudyDayNotes().isEmpty())
         {
             JSONArray jsonStudyDayNotes = new JSONArray();
             for (StudyDayNotes studyDayNote : getStudyDayNotes())

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/query/StudyDayNotesTable.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/query/StudyDayNotesTable.java
@@ -40,9 +40,9 @@ public class StudyDayNotesTable extends SimpleUserSchema.SimpleTable<SNPRC_sched
     @Override
     public QueryUpdateService getUpdateService()
     {
-        return new StudyDayNotesTable.UpdateService(this);
+        return new UpdateService(this);
     }
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected static class UpdateService extends SimpleQueryUpdateService
     {
         public UpdateService(SimpleUserSchema.SimpleTable ti)
         {

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineAnimalJunctionTable.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineAnimalJunctionTable.java
@@ -41,9 +41,9 @@ public class TimelineAnimalJunctionTable extends SimpleUserSchema.SimpleTable<SN
     @Override
     public QueryUpdateService getUpdateService()
     {
-        return new TimelineAnimalJunctionTable.UpdateService(this);
+        return new UpdateService(this);
     }
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected static class UpdateService extends SimpleQueryUpdateService
     {
         public UpdateService(SimpleUserSchema.SimpleTable ti)
         {

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineItemTable.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineItemTable.java
@@ -27,8 +27,6 @@ public class TimelineItemTable extends SimpleUserSchema.SimpleTable<SNPRC_schedu
      *
      * Created by thawkins on 9/17/2018.
      * Create the simple table.
-     * @param schema
-     * @param table
      */
 
     public TimelineItemTable(SNPRC_schedulerUserSchema schema, TableInfo table, ContainerFilter cf)
@@ -56,10 +54,10 @@ public class TimelineItemTable extends SimpleUserSchema.SimpleTable<SNPRC_schedu
     @Override
     public QueryUpdateService getUpdateService()
     {
-        return new TimelineItemTable.UpdateService(this);
+        return new UpdateService(this);
     }
 
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected static class UpdateService extends SimpleQueryUpdateService
     {
         public UpdateService(SimpleUserSchema.SimpleTable ti)
         {

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineProjectItemTable.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineProjectItemTable.java
@@ -49,10 +49,10 @@ public class TimelineProjectItemTable extends SimpleUserSchema.SimpleTable<SNPRC
     @Override
     public QueryUpdateService getUpdateService()
     {
-        return new TimelineProjectItemTable.UpdateService(this);
+        return new UpdateService(this);
     }
 
-    protected class UpdateService extends SimpleQueryUpdateService
+    protected static class UpdateService extends SimpleQueryUpdateService
     {
         public UpdateService(SimpleUserSchema.SimpleTable ti)
         {

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineTable.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/query/TimelineTable.java
@@ -38,8 +38,6 @@ public class TimelineTable extends SimpleTable<SNPRC_schedulerUserSchema>
      * <p>
      * Create the simple table.
      *
-     * @param schema
-     * @param table
      */
 
     public TimelineTable(SNPRC_schedulerUserSchema schema, TableInfo table, ContainerFilter cf)

--- a/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
+++ b/snprc_scheduler/test/src/org/labkey/test/tests/snprc_scheduler/SNPRC_schedulerTest.java
@@ -88,7 +88,7 @@ public class SNPRC_schedulerTest extends AbstractEHRTest implements JavascriptEx
     @BeforeClass
     public static void setupProject()
     {
-        SNPRC_schedulerTest init = (SNPRC_schedulerTest) getCurrentTest();
+        SNPRC_schedulerTest init = getCurrentTest();
         init.doSetup();
     }
 
@@ -152,6 +152,7 @@ public class SNPRC_schedulerTest extends AbstractEHRTest implements JavascriptEx
         return SNPRC_EHR_PATH; // Retrieve reference study from snprc_ehr, not snprc_scheduler
     }
 
+    @Override
     protected boolean skipStudyImportQueryValidation()
     {
         return true;
@@ -338,7 +339,7 @@ public class SNPRC_schedulerTest extends AbstractEHRTest implements JavascriptEx
 
         String projectObjectId = "";
 
-        SelectRowsResponse response = null;
+        SelectRowsResponse response;
         try
         {
             response = selectCmd.execute(cn, getCurrentContainerPath());
@@ -372,7 +373,7 @@ public class SNPRC_schedulerTest extends AbstractEHRTest implements JavascriptEx
             SelectRowsResponse response = selectCmd.execute(cn, getCurrentContainerPath());
 
             Rowset rows = response.getRowset();
-            Map<String, Object> rowMap = null;
+            Map<String, Object> rowMap;
 
             for (Row row : rows)
             {
@@ -409,7 +410,7 @@ public class SNPRC_schedulerTest extends AbstractEHRTest implements JavascriptEx
             SelectRowsResponse response = selectCmd.execute(cn, getCurrentContainerPath());
 
             Rowset rows = response.getRowset();
-            Map<String, Object> rowMap = null;
+            Map<String, Object> rowMap;
 
             for (Row row : rows)
             {
@@ -445,7 +446,7 @@ public class SNPRC_schedulerTest extends AbstractEHRTest implements JavascriptEx
             SelectRowsResponse response = selectCmd.execute(cn, getCurrentContainerPath());
 
             Rowset rows = response.getRowset();
-            Map<String, Object> rowMap = null;
+            Map<String, Object> rowMap;
 
             for (Row row : rows)
             {


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


