### PR TITLE
Switch to non-deprecated getPortalPart() method

### DIFF
--- a/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRController.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRController.java
@@ -236,7 +236,7 @@ public class SNPRC_EHRController extends SpringActionController
             url.addParameter("queryName", queryName);
             url.addParameter("allowChooseQuery", false);
 
-            WebPartFactory factory = Portal.getPortalPartCaseInsensitive("Query");
+            WebPartFactory factory = Portal.getPortalPart("Query");
             Portal.WebPart part = factory.createWebPart();
             part.setProperties(url.getQueryString());
 


### PR DESCRIPTION
#### Rationale
Non-deprecated method is identical

IMO, no need for additional testing