### PR TITLE
Remove pgsql marker from a couple SNPRC modules

### DIFF
--- a/snprc_ehr/module.properties
+++ b/snprc_ehr/module.properties
@@ -1,5 +1,5 @@
 ModuleClass: org.labkey.snprc_ehr.SNPRC_EHRModule
-SupportedDatabases: mssql, pgsql
+SupportedDatabases: mssql
 ManageVersion: true
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/snprc_genetics/module.properties
+++ b/snprc_genetics/module.properties
@@ -1,5 +1,5 @@
 ModuleClass: org.labkey.snprc_genetics.SNPRC_GeneticsModule
-SupportedDatabases: mssql, pgsql
+SupportedDatabases: mssql
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: true


### PR DESCRIPTION
#### Rationale
I marked `snprc_ehr` and `snprc_genetics` as supporting PostgreSQL during my initial migration work. This caused them to end up in the `all_pg` distribution (because all PostgreSQL-supporting modules get pulled in), but they also brought in their `snd` dependency, which does not yet support PostgreSQL. That causes problems when trying to run this distribution in production mode. Best to remove the `pgsql` tag for these modules until they truly support PostgreSQL.

I left `snprc_r24` tagged with `pgsql` because it has no dependencies and should run fine on PostgreSQL.

#### Related Pull Requests
* https://github.com/LabKey/snprcEHRModules/pull/888
