### PR TITLE
Move away from deprecated Gradle syntax

### DIFF
--- a/snprc_genetics/build.gradle
+++ b/snprc_genetics/build.gradle
@@ -34,7 +34,7 @@ project.tasks.register("transformJar", Jar)
         jar.description = "Create the genetics transform jar file"
         jar.from project.sourceSets.transform.output
         jar.from { configurations.transformJars.collect { it.isDirectory() ? it : zipTree(it) }}
-        jar.duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+        jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         jar.archiveBaseName.set("GeneticsTransform")
         jar.destinationDirectory.set(project.layout.buildDirectory.file("artifacts/snprc").get().asFile)
     }

--- a/snprc_r24/build.gradle
+++ b/snprc_r24/build.gradle
@@ -33,15 +33,13 @@ project.tasks.register("transformJar", Jar)
             jar.from { configurations.transformJars.collect { it.isDirectory() ? it : zipTree(it) }}
             jar.archiveBaseName.set("MicrobiomeTransform")
             jar.archiveClassifier.set("transform")
-            jar.duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+            jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             jar.destinationDirectory.set(BuildUtils.getBuildDirFile(project, "artifacts/snprc"))
             jar.manifest {
                 attributes "Main-Class": "MicrobiomeTransform"
             }
         }
 
-project.artifacts {
-    archives project.tasks.transformJar
-}
+project.tasks.assemble.dependsOn(project.tasks.transformJar)
 
 project.tasks.named('module').configure { dependsOn(project.tasks.transformJar) }


### PR DESCRIPTION
#### Rationale
Gradle kindly informs us that:

The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/9.3.1/userguide/upgrading_version_9.html#sec:archives-configurationt

They have also deprecated the use of a method for setting the duplicate strategy, but I don't have their nice message on hand to prove it. You'll just have to believe me on this one.

#### Changes
* duplicateStrategy set with `=`
* declare dependency on `assemble` task instead of using an artifact
