### PR TITLE
Remove miscategorized tests from CustomModules suite

### DIFF
--- a/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
+++ b/snprc_ehr/test/src/org/labkey/test/tests/snprc_ehr/SNPRC_EHRTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.EHR;
 import org.labkey.test.categories.SNPRC;
 import org.labkey.test.components.BodyWebPart;
@@ -72,7 +71,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 
-@Category ({CustomModules.class, EHR.class, SNPRC.class})
+@Category ({EHR.class, SNPRC.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 45)
 public class SNPRC_EHRTest extends AbstractGenericEHRTest implements SqlserverOnlyTest
 {


### PR DESCRIPTION
#### Rationale
EHR tests don't belong in the `CustomModules` suite. They aren't present where we run that suite on TeamCity and the suite runs a bunch of unexpected tests elsewhere.

#### Related Pull Requests
* N/A
