### PR TITLE
Drop redundant index

### DIFF
--- a/snprc_scheduler/resources/schemas/dbscripts/postgresql/snprc_scheduler-26.000-26.001.sql
+++ b/snprc_scheduler/resources/schemas/dbscripts/postgresql/snprc_scheduler-26.000-26.001.sql
@@ -1,0 +1,2 @@
+-- Dropping NONUNIQUE idx_timelineprojectitemfk1 [TimelineObjectId] because it overlaps with PRIMARY pk_timelineprojectitem [TimelineObjectId, ProjectItemId]
+DROP INDEX snprc_scheduler.idx_timelineprojectitemfk1;

--- a/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
+++ b/snprc_scheduler/src/org/labkey/snprc_scheduler/SNPRC_schedulerModule.java
@@ -44,7 +44,7 @@ public class SNPRC_schedulerModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 26.000;
+        return 26.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Our overlapping indices test pointed out that this index is redundant with the PK