### PR TITLE
Fix null sort order error and date drift on Animal Group Management Interface

### DIFF
--- a/snprc_ehr/resources/web/snprc_ehr/lib/stores/AnimalGroupsStore.js
+++ b/snprc_ehr/resources/web/snprc_ehr/lib/stores/AnimalGroupsStore.js
@@ -8,11 +8,10 @@
  */
 Ext4.define("AnimalGroupsStore", {
     extend: 'Ext.data.Store',
-    fields: ['code', 'categoryCode', 'name', {name: 'date', type: 'date', submitFormat: 'Y-m-d'}, {
-        name: 'endDate',
-        type: 'date',
-        submitFormat: 'Y-m-d'
-    }, 'comment', 'sortOrder'],
+    fields: ['code', 'categoryCode', 'name',
+        {name: 'date', type: 'date', dateReadFormat: 'Y-m-d', submitFormat: 'Y-m-d'},
+        {name: 'endDate', type: 'date', dateReadFormat: 'Y-m-d', submitFormat: 'Y-m-d' },
+        'comment', 'sortOrder'],
     autoLoad: false,
     proxy: {
         type: 'ajax',

--- a/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalGroupsController.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/controllers/AnimalGroupsController.java
@@ -464,7 +464,7 @@ public class AnimalGroupsController extends SpringActionController
                     if (mappedRows.get("code") != null && (Integer) mappedRows.get("code") != 0)
                     {
                         mappedRows.put("category_code", o.get("categoryCode"));
-                        mappedRows.put("sort_order", o.get("sortOrder"));
+                        mappedRows.put("sort_order", o.isNull("sortOrder") ? null : o.get("sortOrder"));
 
                         // update existing row
                         rowsList.add(mappedRows);
@@ -482,7 +482,7 @@ public class AnimalGroupsController extends SpringActionController
                         //mappedRows.put("code", -1);
                         mappedRows.put("objectId", GUID.makeGUID());
                         mappedRows.put("category_code", o.get("categoryCode"));
-                        mappedRows.put("sort_order", o.get("sortOrder"));
+                        mappedRows.put("sort_order", o.isNull("sortOrder") ? null : o.get("sortOrder"));
                         rowsList.add(mappedRows);
                         qus.insertRows(getUser(), getContainer(), rowsList, batchErrors, null, null);
                         if (batchErrors.hasErrors()) throw batchErrors;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/domain/AnimalGroup.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/domain/AnimalGroup.java
@@ -113,8 +113,8 @@ public class AnimalGroup extends Entity
     public JSONObject toJSON()
     {
         JSONObject json = new JSONObject(this);
-        json.put("date",    date    == null ? null : DateUtil.toISO(date).substring(0, 10));
-        json.put("endDate", endDate == null ? null : DateUtil.toISO(endDate).substring(0, 10));
+        json.put("date", DateUtil.formatIsoDate(date));
+        json.put("endDate", DateUtil.formatIsoDate(endDate));
         return json;
     }
 }

--- a/snprc_ehr/src/org/labkey/snprc_ehr/domain/AnimalGroup.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/domain/AnimalGroup.java
@@ -17,6 +17,7 @@ package org.labkey.snprc_ehr.domain;
 
 import org.json.JSONObject;
 import org.labkey.api.data.Entity;
+import org.labkey.api.util.DateUtil;
 
 import java.util.Date;
 
@@ -111,6 +112,9 @@ public class AnimalGroup extends Entity
 
     public JSONObject toJSON()
     {
-        return new JSONObject(this);
+        JSONObject json = new JSONObject(this);
+        json.put("date",    date    == null ? null : DateUtil.toISO(date).substring(0, 10));
+        json.put("endDate", endDate == null ? null : DateUtil.toISO(endDate).substring(0, 10));
+        return json;
     }
 }


### PR DESCRIPTION
Fixes two bugs on the Animal Groups data-entry form (animalGroupCategories):

1. "Update failed: Unable to convert value 'null' to Integer" when saving a row with a blank Sort Order
- AnimalGroupsController.UpdateGroupsAction was passing the JSON null sentinel straight to the row map. Guarded sort_order with o.isNull("sortOrder") so a blank field is sent as a real SQL null (the column is nullable).

2. Start/End date drifting back one day on every edit (timezone round-trip)
This needed a coordinated server + client change; neither half fixes it alone:
- Server (AnimalGroup.toJSON): format date and endDate with DateUtil.formatIsoDate(...) so the payload carries a bare Y-m-d string instead of a zoned datetime.
- Client (AnimalGroupsStore.js): added dateReadFormat: 'Y-m-d' to the date and endDate fields so ExtJS parses that string as a local date rather than UTC midnight (which shifted it to the prior day in Central time).