### PR TITLE
Fix isnumeric() usage in SNPRC demographics queries

### DIFF
--- a/snprc_ehr/resources/queries/study/animalDemographics.sql
+++ b/snprc_ehr/resources/queries/study/animalDemographics.sql
@@ -9,7 +9,7 @@ SELECT
     d.species.arc_species_code as species,
     CASE
         WHEN h.cage is null THEN h.room
-        WHEN isnumeric(h.cage) = 1 THEN (h.room || '-' || cast(cast(h.cage as DECIMAL) as varchar) )
+        WHEN isnumeric(h.cage) THEN (h.room || '-' || cast(cast(h.cage as DECIMAL) as varchar) )
         ELSE (h.room || '-' || h.cage)
         END AS Location,
     h.room as room,

--- a/snprc_ehr/resources/queries/study/demographicsCurLocation.sql
+++ b/snprc_ehr/resources/queries/study/demographicsCurLocation.sql
@@ -11,7 +11,7 @@
 SELECT d2.id,
        CASE
          WHEN d2.cage is null THEN d2.room
-         WHEN isnumeric(d2.cage) = 1 THEN (d2.room || '-' || cast(cast(d2.cage as DECIMAL) as varchar) )
+         WHEN isnumeric(d2.cage) THEN (d2.room || '-' || cast(cast(d2.cage as DECIMAL) as varchar) )
          ELSE (d2.room || '-' || d2.cage)
          END AS Location,
        d2.room.area, d2.room, d2.cage,


### PR DESCRIPTION
## Rationale
The related PR migrated LabKey SQL `isnumeric()` from a SQL Server passthrough returning `bit` to a portable method returning `JdbcType.BOOLEAN`. On SQL Server the dialect now emits `(ISNUMERIC(x) = 1)`, so the legacy `isnumeric(x) = 1` pattern in these two saved queries is generated as `((ISNUMERIC(x) = 1) = 1)` — invalid T-SQL, which fails the SNPRC dataset import trigger that resolves `study.demographicsCurLocation`.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7798
- https://github.com/LabKey/premiumModules/pull/657

## Changes
- drop the `= 1` from `WHEN isnumeric(...) = 1 THEN …`.