### PR TITLE
Fix missing space before WHERE in SND PackageUserSchema.getFromSQLJoin

### DIFF
--- a/snd/src/org/labkey/snd/PackageUserSchema.java
+++ b/snd/src/org/labkey/snd/PackageUserSchema.java
@@ -251,7 +251,7 @@ public class PackageUserSchema extends UserSchema
             fromSql.append("FROM ").append(eventData.getFromSQL("eventdata"));
             if (withEventJoin)
                 fromSql.append(" INNER JOIN ").append(events.getFromSQL("events")).append( " ON eventdata.eventid = events.eventid\n");
-            fromSql.append("WHERE eventdata.Container=").appendValue(getContainer());
+            fromSql.append(" WHERE eventdata.Container=").appendValue(getContainer());
             if (null == me || me.superPkgIds.isEmpty())
                 fromSql.append(" AND (0=1)");
             else


### PR DESCRIPTION
## Rationale
When a Packages user-schema query didn't reference any of the "event" columns (SubjectId, Date, QcState, SequenceNum), PackageTableInfo.getFromSQLJoin took the withEventJoin=false path and appended "WHERE eventdata.Container=…" immediately after the eventdata subquery alias produced by eventData.getFromSQL("eventdata"). With no separator between the alias and the keyword, the emitted SQL looked like `…) eventdataWHERE eventdata.Container=…`, which SQL Server rejected with Incorrect syntax near 'eventdata'.

## Related Pull Requests

## Changes
- prepend a leading space to the WHERE clause