### PR TITLE
Handle BIGINT exp ObjectId in SND attribute table

### DIFF
--- a/snd/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/snd/src/org/labkey/snd/query/AttributeDataTable.java
@@ -434,8 +434,9 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
             {
                 for (Map<String, Object> row : oldRows)
                 {
-                    Integer objectId = (Integer) row.get("ObjectId");
-                    Integer propertyId = (Integer) row.get("PropertyId");
+                    // exp.ObjectProperty.ObjectId is BIGINT as of exp 25.005, so the value arrives as a Long
+                    Number objectId = (Number) row.get("ObjectId");
+                    Number propertyId = (Number) row.get("PropertyId");
 
                     SqlExecutor executor = new SqlExecutor(_expSchema);
                     SQLFragment deleteObjProp = new SQLFragment("delete from " + _expSchema.getName() + ".ObjectProperty\n");

--- a/snd/src/org/labkey/snd/query/EventDataTable.java
+++ b/snd/src/org/labkey/snd/query/EventDataTable.java
@@ -68,7 +68,7 @@ public class EventDataTable extends AbstractSNDTableInfo
     @Override
     public void addColumns()
     {
-        BaseColumnInfo objectid = new BaseColumnInfo("ObjectId", this, JdbcType.INTEGER)
+        BaseColumnInfo objectid = new BaseColumnInfo("ObjectId", this, JdbcType.BIGINT)
         {
             @Override
             public SQLFragment getValueSql(String tableAliasName)


### PR DESCRIPTION
## Rationale

The `_SND Attribute Data` ETL fails on every run that includes a delete at SNPRC with `java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer`. exp 25.005 widened `exp.Object.ObjectId` and `exp.ObjectProperty.ObjectId` to BIGINT, but `AttributeDataTable.UpdateService.deleteRows` still cast the delete key to `Integer`. `TransformTask` builds each delete key from the target table's PK columns, which for this table are `exp.ObjectProperty`'s `ObjectId` and `PropertyId`, so the first row aborts the step.

## Related Pull Requests

None.

## Changes

- `AttributeDataTable.UpdateService.deleteRows` casts `ObjectId` and `PropertyId` to `Number` rather than `Integer`.
- `EventDataTable` declares its injected `exp.Object.ObjectId` column as `JdbcType.BIGINT` instead of `JdbcType.INTEGER`, matching the widened column.
