### PR TITLE
Drop redundant unique index on snprc_ehr.labwork_services.ServiceId

### DIFF
--- a/snprc_ehr/resources/schemas/dbscripts/postgresql/snprc_ehr-26.001-26.002.sql
+++ b/snprc_ehr/resources/schemas/dbscripts/postgresql/snprc_ehr-26.001-26.002.sql
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+-- Dropping UNIQUE idx_labwork_services_serviceid [ServiceId] because it overlaps with PRIMARY pk_snprc_labwork_services [ServiceId]
+DROP INDEX snprc_ehr.idx_labwork_services_serviceid;

--- a/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRModule.java
+++ b/snprc_ehr/src/org/labkey/snprc_ehr/SNPRC_EHRModule.java
@@ -117,7 +117,7 @@ public class SNPRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 26.001;
+        return 26.002;
     }
 
     @Nullable


### PR DESCRIPTION
## Rationale
snprc_ehr.labwork_services declares PRIMARY KEY (ServiceId) and then creates idx_labwork_services_serviceid, a UNIQUE index on that same column. The primary key's B-tree already enforces the identical uniqueness guarantee and serves the same queries, so the second index costs write throughput and storage while buying nothing. ToolsController$TestCase.testOverlappingIndices fails on PostgreSQL because of it.

The index dates to 2017, when the table's primary key was changed to ServiceId. It only became visible to this test after PostgreSQL support was added to the SNPRC modules, since the test is gated on isPostgreSQL(),

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- Drop redundant unique index on snprc_ehr.labwork_services.ServiceId
